### PR TITLE
Fix .tar.gz unpacking in Windows

### DIFF
--- a/yotta/lib/access_common.py
+++ b/yotta/lib/access_common.py
@@ -69,7 +69,7 @@ def unpackTarballStream(stream, into_directory, hash=(None, None)):
     # overwriting our tar archive with something that unpacks to an absolute
     # path when we might be running sudo'd
     try:
-        fd = os.open(download_fname, os.O_CREAT | os.O_EXCL | os.O_RDWR | os.O_BINARY)
+        fd = os.open(download_fname, os.O_CREAT | os.O_EXCL | os.O_RDWR | getattr(os, "O_BINARY", 0))
         with os.fdopen(fd, 'rb+') as f:
             f.seek(0)
             while True:


### PR DESCRIPTION
From http://docs.python.org/2/library/os.html#os.open:

"In particular, on Windows adding O_BINARY is needed to open files in binary mode"
