### PR TITLE
Make .yotta_ignore work in Windows

### DIFF
--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -176,6 +176,7 @@ class Pack(object):
         return r
 
     def ignores(self, path):
+        path = path.replace("\\", '/')
         ''' Test if this module ignores the file at "path" '''
         for exp in self.ignore_patterns:
             if exp.match(path):


### PR DESCRIPTION
.yotta_ignore wasn't working properly because of differences in path separator.
Not sure if this is the proper fix or rather the paths should be "normalized"
to use only '/' before reaching the "ignores" function.
