### PR TITLE
'Fix' ninja build files on Windows

### DIFF
--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -112,7 +112,9 @@ class Target(pack.Pack):
         else:
             commands.append(['cmake', '-G', args.cmake_generator, '.'])
         build_command = self.overrideBuildCommand(args.cmake_generator)
-        if args.cmake_generator == "Ninja":
+        # cmake error: the generated Ninja build file will not work on windows when arguments are read from
+        # a file (@file) instead of the command line, since '\' in @file is interpreted as an escape sequence.
+        if args.cmake_generator == "Ninja" and os.name == 'nt':
             commands.append(["sed", "-i", "-e", "s#\\\\#/#g", "build.ninja"])
         if build_command:
             commands.append(build_command)


### PR DESCRIPTION
cmake doesn't generate ninja build files on Windows properly:

http://www.cmake.org/Bug/view.php?id=15278

The change below will 'fix' this from yotta by running 'sed' to change all the back slased in the ninja build file to forward slashes.
Also, this 'fix' makes me feel dirty.
