### PR TITLE
Fix for 'link' issues in Windows

### DIFF
--- a/yotta/lib/fsutils.py
+++ b/yotta/lib/fsutils.py
@@ -52,6 +52,7 @@ links = __import__("fsutils_win" if os.name == 'nt' else "fsutils_posix", global
 isLink = links.isLink
 tryReadLink = links.tryReadLink
 _symlink = links._symlink
+realpath = links.realpath
 
 # !!! FIXME: the logic in the "except" block below probably doesn't work in Windows
 def symlink(source, link_name):

--- a/yotta/lib/fsutils_posix.py
+++ b/yotta/lib/fsutils_posix.py
@@ -18,3 +18,5 @@ def tryReadLink(path):
 def _symlink(source, link_name):
     os.symlink(source, link_name)
 
+def realpath(path):
+    return os.path.realpath(path)

--- a/yotta/lib/fsutils_win.py
+++ b/yotta/lib/fsutils_win.py
@@ -10,6 +10,7 @@
 
 # ntfsutils, 2-clause BSD, NTFS link handling, pip install ntfsutils
 import ntfsutils.junction as junction
+import os
 
 def isLink(path):
     return junction.isjunction(path)
@@ -22,3 +23,6 @@ def tryReadLink(path):
 
 def _symlink(source, link_name):
     junction.create(source, link_name)
+
+def realpath(path):
+    return os.path.abspath(tryReadLink(path) or path)

--- a/yotta/link.py
+++ b/yotta/link.py
@@ -61,7 +61,7 @@ def execCommand(args, following_args):
         dst = os.path.join(folders.globalInstallDirectory(), c.getName())
 
     if args.component:
-        realsrc = os.path.realpath(src)
+        realsrc = fsutils.realpath(src)
         if src == realsrc:
             logging.warning(
               ('%s -> %s -> ' % (dst, src)) + colorama.Fore.RED + 'BROKEN' + colorama.Fore.RESET

--- a/yotta/link_target.py
+++ b/yotta/link_target.py
@@ -44,7 +44,7 @@ def execCommand(args, following_args):
         dst = os.path.join(folders.globalTargetInstallDirectory(), c.getName())
 
     if args.target:
-        realsrc = os.path.realpath(src)
+        realsrc = fsutils.realpath(src)
         if src == realsrc:
             logging.warning(
               ('%s -> %s -> ' % (dst, src)) + colorama.Fore.RED + 'BROKEN' + colorama.Fore.RESET

--- a/yotta/list.py
+++ b/yotta/list.py
@@ -19,6 +19,8 @@ from .lib import target
 # access, , get components (and check versions), internal
 from .lib import access
 from .lib import access_common
+# fsutils, , misc filesystem utils, internal
+from .lib import fsutils
 
 def addOptions(parser):
     parser.add_argument('--all', '-a', dest='show_all', default=False, action='store_true',
@@ -103,7 +105,7 @@ def printComponentDepsRecursive(
     if len(installed_at):
         line += u' ' + DIM + installed_at + RESET
     if component.installedLinked():
-        line += GREEN + BRIGHT + u' -> ' + RESET + GREEN + os.path.realpath(component.path) + RESET 
+        line += GREEN + BRIGHT + u' -> ' + RESET + GREEN + fsutils.realpath(component.path) + RESET
 
     putln(line)
     


### PR DESCRIPTION
os.path.realpath doesn't follow links in Windows:

http://bugs.python.org/issue9949

This makes 'yotta link' and 'yotta link-target' unusable from Windows.
This patch fixes that by moving 'realpath' in fsutils and providing a
(hopefully) correct implementation for Windows. Tested with
'yotta link-target'.
