### PR TITLE
Use 'ninja' by default on Windows

### DIFF
--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -62,7 +62,8 @@ class Target(pack.Pack):
     
     @classmethod
     def addBuildOptions(cls, parser):
-        parser.add_argument('-G', '--cmake-generator', dest='cmake_generator', default='Unix Makefiles',
+        parser.add_argument('-G', '--cmake-generator', dest='cmake_generator',
+           default=('Unix Makefiles', 'Ninja')[os.name == 'nt'],
            choices=(
                'Unix Makefiles',
                'Ninja',


### PR DESCRIPTION
'ninja' is much better supported (and much faster) than 'make' in
Windows, so make it the default build method for this platform.
