### PR TITLE
Include all matching target dependencies, instead of just one.

### DIFF
--- a/yotta/lib/component.py
+++ b/yotta/lib/component.py
@@ -118,7 +118,6 @@ class Component(pack.Pack):
                         (target, t, self.getName())
                     )
                     deps += self.description['targetDependencies'][t].items()
-                    break
         return deps
 
     def getDependencies(self,


### PR DESCRIPTION
This commit changes the behaviour of the targetDependencies section of
module.json files. Previously, if this section contained target-specific
dependencies for multiple target identifiers, then zero or one of those
sections was chosen, based on which of the target identifiers occured higher up
in the current target description's similarTo list.

Now the behaviour is to choose all matching sections. This makes it possible to
include multiple sections based on independent decisions about the target (such
as which compiler is being used, and which exact board is being compiled for).

This doesn't change the behaviour of any existing yotta modules that I'm aware
of.
