### PR TITLE
'Fix' sed search pattern in Windows

### DIFF
--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -118,7 +118,7 @@ class Target(pack.Pack):
         # cmake error: the generated Ninja build file will not work on windows when arguments are read from
         # a file (@file) instead of the command line, since '\' in @file is interpreted as an escape sequence.
         if args.cmake_generator == "Ninja" and os.name == 'nt':
-            commands.append(["sed", "-i", "-e", "s#\\\\#/#g", "build.ninja"])
+            commands.append(["sed", "-i", "-e", "s#\\\\#/#g", "-e", "'s#/\"#\\\\\"#g'", "build.ninja"])
         if build_command:
             commands.append(build_command + build_args)
         else:


### PR DESCRIPTION
(fair warning: this might challenge your sanity and destroy that last glimmer
of fate in humanity that you have left. So proceed at your own risk).

So, the previous 'sed' commit was obviously a bad, ugly hack and it was only a
matter of time until it broke. Which happened when some part of our code tried
to use the YOTTA_COMPONENT_VERSION macro defined in the command line. The macro
is initially defined correctly as YOTTA_COMPONENT_VERSION=\"M.m.p\", but of
course my 'sed' expression blindly converts every backslash to a slash, which
turns that expression into YOTTA_COMPONENT_VERSION=/"M.m.p/", which in turn
breaks compilation. What's the fix for that then? That's right! Add a second
sed expression, that looks for all /" strings and converts them back to \"!

I feel like I should have my software engineer degree revoked and be banished
from society for having the audacity to submit this disaster, but unfortunately
Windows is so dreadful when it comes to using Unix style tools (such as make)
that one has to resort to insanity and dark magic to fix things. make in Windows
is broken in ways that make the brave shiver in terror, randomly throwing
cryptic Windows error messages on some machines and working on others, but being
painfully slow when it runs. ninja is fine, but cmake's generation of ninja
build files is broken:

http://www.cmake.org/Bug/view.php?id=15278

The best solution for this scenario would be for the above bug to be fixed,
but it looks like we'll have to wait quite a bit for that to happen
(target version is 3.2, current cmake version is 3.1.0-rc3).

I'm perfectly aware that this new 'fix' will break into shiny little
pieces of dead bits in a not so distant future. Hell, I don't even expect
it to be merged. in fact, I hope it won't be merged. I hope people will
come to me, smack me hard in the face for submitting this and then present
me with that nice and clean solution that I've completely missed until now.
