### PR TITLE
Fix PyCrypto dependency version in Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,15 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-platform_deps = ['ntfsutils'] if os.name == 'nt' else []
+# On Windows, fix the version of PyCrypto dependency to 2.6, so we can use
+# the binary installer from voidspace.org.uk (otherwise pip tries to install
+# a newer pycrypto from PyPI). Also, we need 'ntfsutils' in Windows
+if os.name == 'nt':
+    platform_deps = ['ntfsutils']
+    pycrypto_dep = 'PyCrypto==2.6'
+else:
+    platform_deps = []
+    pycrypto_dep = 'PyCrypto>=2.5,<3'
 
 setup(
     name = "yotta",
@@ -36,5 +44,5 @@ setup(
         ],
     },
     test_suite = 'yotta.test',
-    install_requires=['semantic_version>=2.3.1,<3', 'requests>=2.5,<3', 'PyGithub>1.25,<2', 'colorama>=0.3,<0.4', 'hgapi>=1.7,<2', 'Jinja2>2.7.0,<3', 'PyCrypto>=2.5,<3', 'PyJWT>=0.3,<0.4', 'pathlib>=1.0.1,<1.1'] + platform_deps
+    install_requires=['semantic_version>=2.3.1,<3', 'requests>=2.5,<3', 'PyGithub>1.25,<2', 'colorama>=0.3,<0.4', 'hgapi>=1.7,<2', 'Jinja2>2.7.0,<3', pycrypto_dep, 'PyJWT>=0.3,<0.4', 'pathlib>=1.0.1,<1.1'] + platform_deps
 )


### PR DESCRIPTION
Fix the PyCrypto dependency to version 2.6 on Windows, which is what is
provided on voidspace.org.uk as a binary installer. Otherwise pip
tries to install the latest version from PyPI, even if the requirement
is already satisfied after running the PyCrypto binary installer.
Of course, installing the latest version from PyPI fails in the
absence of a C compiler.
