### PR TITLE
Made cmakefile generation aware of XCode resource directory

### DIFF
--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -590,7 +590,7 @@ class CMakeGen(object):
             resource_files = []
             for f in resource_subdirs:
                 for root, dires, files in os.walk(f):
-                    if (root.endswith(".xcassets")):
+                    if root.endswith(".xcassets"):
                         resource_files.append(root)
                         break;
                     for f in files:

--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -590,6 +590,9 @@ class CMakeGen(object):
             resource_files = []
             for f in resource_subdirs:
                 for root, dires, files in os.walk(f):
+                    if (root.endswith(".xcassets")):
+                        resource_files.append(root)
+                        break;
                     for f in files:
                         resource_files.append(os.path.join(root, f))
 


### PR DESCRIPTION
 *.xcassets folders in xcode are added as folder resources and shouldn't be recursed.
