### PR TITLE
optimise (RelWithDebInfo) by default

### DIFF
--- a/yotta/build.py
+++ b/yotta/build.py
@@ -22,7 +22,8 @@ def addOptions(parser):
         action='store_true', default=False,
         help='Only generate CMakeLists, don\'t run CMake or build'
     )
-    parser.add_argument('-r', '--release-build', dest='release_build', action='store_true', default=False)
+    parser.add_argument('-r', '--release-build', dest='release_build', action='store_true', default=True)
+    parser.add_argument('-d', '--debug-build', dest='release_build', action='store_false', default=True)
     # the target class adds its own build-system specific options. In the
     # future we probably want to load these from a target instance, rather than
     # from the class


### PR DESCRIPTION
use `yotta build -d` to build a non-optimised debug build

This change is to ensure that people's "default experience" with yotta puts things that are built with it in the best possible light (especially on embedded targets where the optimised build substantially reduces code-size).

