### PR TITLE
respect 'private' key in module.json; add corresponding test; 

### DIFF
--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -280,6 +280,8 @@ class Pack(object):
             errors that occured, or None if successful.
             No VCS tagging is performed.
         '''
+        if 'private' in self.description and self.description['private'].lower() != 'false':
+            return "this %s is private and cannot be published" % (self.description_filename.split('.')[0])
         upload_archive = os.path.join(self.path, 'upload.tar.gz')
         fsutils.rmF(upload_archive)
         fd = os.open(upload_archive, os.O_CREAT | os.O_EXCL | os.O_RDWR | getattr(os, "O_BINARY", 0))

--- a/yotta/test/cli/install.py
+++ b/yotta/test/cli/install.py
@@ -10,6 +10,7 @@ import unittest
 import os
 import subprocess
 from collections import namedtuple
+import tempfile
 
 # internal modules:
 from yotta.lib.fsutils import mkDirP, rmRf
@@ -19,7 +20,6 @@ from yotta.lib import settings
 from yotta import install
 
 
-Test_Dir = '/tmp/yotta/version_cli_test'
 Test_Name = 'testing-dummy'
 Test_Github_Name = "autopulated/github-access-testing"
 Test_Target = "x86-osx-native,*"
@@ -62,11 +62,11 @@ def ensureGithubConfig():
 
 class TestCLIInstall(unittest.TestCase):
     def setUp(self):
-        mkDirP(Test_Dir)
+        self.test_dir = tempfile.mkdtemp() 
         ensureGithubConfig()
 
     def tearDown(self):
-        rmRf(Test_Dir)
+        rmRf(self.test_dir)
 
     def test_installRegistryRef(self):
         stdout = self.runCheckCommand(['--target', Test_Target, 'install', Test_Name])
@@ -75,7 +75,7 @@ class TestCLIInstall(unittest.TestCase):
         stdout = self.runCheckCommand(['--target', Test_Target, 'install', Test_Github_Name])
 
     def test_installDeps(self):
-        with open(os.path.join(Test_Dir, 'module.json'), 'w') as f:
+        with open(os.path.join(self.test_dir, 'module.json'), 'w') as f:
             f.write(Test_Module_JSON)
         stdout = self.runCheckCommand(['--target', Test_Target, 'install'])
 
@@ -90,7 +90,7 @@ class TestCLIInstall(unittest.TestCase):
         self.assertTrue(stdout.find('hg-access-testing') != -1)
 
     def runCheckCommand(self, args):
-        stdout, stderr, statuscode = cli.run(args, cwd=Test_Dir)
+        stdout, stderr, statuscode = cli.run(args, cwd=self.test_dir)
         self.assertEqual(statuscode, 0)
         return stdout or stderr
 

--- a/yotta/test/cli/owners.py
+++ b/yotta/test/cli/owners.py
@@ -8,13 +8,13 @@
 # standard library modules, , ,
 import unittest
 import os
+import tempfile
 
 # internal modules:
 from yotta.lib.fsutils import mkDirP, rmRf
 from . import cli
 
 
-Test_Dir = '/tmp/yotta/version_cli_test'
 Test_Module_JSON = '''{
   "name": "git-access-testing",
   "version": "0.0.2",
@@ -36,12 +36,12 @@ Test_Module_JSON = '''{
 
 class TestCLIOwners(unittest.TestCase):
     def setUp(self):
-        mkDirP(Test_Dir)
-        with open(os.path.join(Test_Dir, 'module.json'), 'w') as f:
+        self.test_dir = tempfile.mkdtemp()
+        with open(os.path.join(self.test_dir, 'module.json'), 'w') as f:
             f.write(Test_Module_JSON)
         
     def tearDown(self):
-        rmRf(Test_Dir)
+        rmRf(self.test_dir)
 
     # you have have to be authenticated to list owners, so this doesn't work
     # yet...
@@ -50,7 +50,7 @@ class TestCLIOwners(unittest.TestCase):
     #    self.assertTrue(stdout.find('autopulated@gmail.com') != -1)
 
     def runCheckCommand(self, args):
-        stdout, stderr, statuscode = cli.run(args, cwd=Test_Dir)
+        stdout, stderr, statuscode = cli.run(args, cwd=self.test_dir)
         self.assertEqual(statuscode, 0)
         return stdout or stderr
 

--- a/yotta/test/cli/publish.py
+++ b/yotta/test/cli/publish.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+
+# standard library modules, , ,
+import unittest
+import os
+import subprocess
+from collections import namedtuple
+import tempfile
+
+# internal modules:
+from yotta.lib.fsutils import mkDirP, rmRf
+from . import cli
+from yotta.lib import version
+from yotta.lib import settings
+from yotta import install
+
+
+Test_Target = "x86-osx-native,*"
+
+Private_Module_JSON = '''{
+  "name": "testmod",
+  "version": "0.0.0",
+  "description": "a test module",
+  "private": "true",
+  "keywords": [
+  ],
+  "author": "Someone Somewhere <someone.somewhere@yottabuild.org>",
+  "repository": {
+    "url": "git@github.com:mbedmicro/testmod.git",
+    "type": "git"
+  },
+  "homepage": "https://github.com/mbedmicro/testmod",
+  "licenses": [
+    {
+      "url": "https://spdx.org/licenses/Apache-2.0",
+      "type": "Apache-2.0"
+    }
+  ],
+  "dependencies": {
+    "testing-dummy": "*"
+  },
+  "targetDependencies": {
+    "x86-osx-native": {
+        "other-testing-dummy": "git@bitbucket.org:autopulated/other-testing-dummy.git#0.0.1"
+    }
+  }
+}
+'''
+
+class TestCLIPublish(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        rmRf(self.test_dir)
+
+    def test_publishPrivate(self):
+        with open(os.path.join(self.test_dir, 'module.json'), 'w') as f:
+            f.write(Private_Module_JSON)
+        stdout, stderr, status = cli.run(['--target', Test_Target, 'publish'], cwd=self.test_dir)
+        self.assertNotEqual(status, 0)
+        self.assertTrue('is private and cannot be published' in ('%s %s' % (stdout, stderr)))
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+
+

--- a/yotta/test/cli/target.py
+++ b/yotta/test/cli/target.py
@@ -8,13 +8,13 @@
 # standard library modules, , ,
 import unittest
 import os
+import tempfile
 
 # internal modules:
 from yotta.lib.fsutils import mkDirP, rmRf
 from . import cli
 
 
-Test_Dir = '/tmp/yotta/version_cli_test'
 Test_Module_JSON = '''{
   "name": "testmod",
   "version": "0.0.0",
@@ -40,12 +40,12 @@ Test_Module_JSON = '''{
 
 class TestCLITarget(unittest.TestCase):
     def setUp(self):
-        mkDirP(Test_Dir)
-        with open(os.path.join(Test_Dir, 'module.json'), 'w') as f:
+        self.test_dir = tempfile.mkdtemp()
+        with open(os.path.join(self.test_dir, 'module.json'), 'w') as f:
             f.write(Test_Module_JSON)
         
     def tearDown(self):
-        rmRf(Test_Dir)
+        rmRf(self.test_dir)
 
     def test_setTarget(self):
         stdout = self.runCheckCommand(['target', 'testtarget'])
@@ -54,7 +54,7 @@ class TestCLITarget(unittest.TestCase):
         stdout = self.runCheckCommand(['target', 'x86-linux-native'])
 
     def runCheckCommand(self, args):
-        stdout, stderr, statuscode = cli.run(args, cwd=Test_Dir)
+        stdout, stderr, statuscode = cli.run(args, cwd=self.test_dir)
         self.assertEqual(statuscode, 0)
         return stdout or stderr
 

--- a/yotta/test/cli/version.py
+++ b/yotta/test/cli/version.py
@@ -8,13 +8,13 @@
 # standard library modules, , ,
 import unittest
 import os
+import tempfile
 
 # internal modules:
 from yotta.lib.fsutils import mkDirP, rmRf
 from . import cli
 
 
-Test_Dir = '/tmp/yotta/version_cli_test'
 Test_Module_JSON = '''{
   "name": "testmod",
   "version": "0.0.0",
@@ -40,12 +40,12 @@ Test_Module_JSON = '''{
 
 class TestCLIVersion(unittest.TestCase):
     def setUp(self):
-        mkDirP(Test_Dir)
-        with open(os.path.join(Test_Dir, 'module.json'), 'w') as f:
+        self.test_dir = tempfile.mkdtemp()
+        with open(os.path.join(self.test_dir, 'module.json'), 'w') as f:
             f.write(Test_Module_JSON)
         
     def tearDown(self):
-        rmRf(Test_Dir)
+        rmRf(self.test_dir)
 
     def test_displayVersion(self):
         stdout = self.runCheckCommand(['version'])
@@ -69,7 +69,7 @@ class TestCLIVersion(unittest.TestCase):
         self.assertTrue(stdout.find('1.2.3-alpha1') != -1)
 
     def runCheckCommand(self, args):
-        stdout, stderr, statuscode = cli.run(args, cwd=Test_Dir)
+        stdout, stderr, statuscode = cli.run(args, cwd=self.test_dir)
         self.assertEqual(statuscode, 0)
         return stdout or stderr
 


### PR DESCRIPTION
also improve test temporary directory creation