### PR TITLE
support setting config settings with env vars; use that for tests

### DIFF
--- a/yotta/test/cli/install.py
+++ b/yotta/test/cli/install.py
@@ -23,8 +23,6 @@ Test_Dir = '/tmp/yotta/version_cli_test'
 Test_Name = 'testing-dummy'
 Test_Github_Name = "autopulated/github-access-testing"
 Test_Target = "x86-osx-native,*"
-Test_Username = 'yottatest'
-Test_Access_Token = 'c53aadbd89caefdcadb0d43d18ef863e1d9cbcf4'
 
 Test_Module_JSON = '''{
   "name": "testmod",
@@ -58,7 +56,7 @@ Test_Module_JSON = '''{
 def ensureGithubConfig():
     # ensure we have authentication for the test github account
     if not settings.getProperty('github', 'authtoken'):
-        settings.setProperty('github', 'authtoken', Test_Access_Token)
+        raise Exception('a github authtoken must be specified in the environment (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)')
 
 class TestCLIInstall(unittest.TestCase):
     def setUp(self):

--- a/yotta/test/cli/install.py
+++ b/yotta/test/cli/install.py
@@ -10,6 +10,7 @@ import unittest
 import os
 import subprocess
 from collections import namedtuple
+import logging
 
 # internal modules:
 from yotta.lib.fsutils import mkDirP, rmRf
@@ -53,10 +54,11 @@ Test_Module_JSON = '''{
 }
 '''
 
-def ensureGithubConfig():
-    # ensure we have authentication for the test github account
+def hasGithubConfig():
+    # can't run tests that hit github without an authn token
     if not settings.getProperty('github', 'authtoken'):
-        raise Exception('a github authtoken must be specified in the environment (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)')
+        return False
+    return True
 
 class TestCLIInstall(unittest.TestCase):
     def setUp(self):
@@ -65,13 +67,16 @@ class TestCLIInstall(unittest.TestCase):
 
     def tearDown(self):
         rmRf(Test_Dir)
-
+    
+    @unittest.skipIf(not hasGithubConfig(), "a github authtoken must be specified for this test (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)")
     def test_installRegistryRef(self):
         stdout = self.runCheckCommand(['--target', Test_Target, 'install', Test_Name])
 
+    @unittest.skipIf(not hasGithubConfig(), "a github authtoken must be specified for this test (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)")
     def test_installGithubRef(self):
         stdout = self.runCheckCommand(['--target', Test_Target, 'install', Test_Github_Name])
 
+    @unittest.skipIf(not hasGithubConfig(), "a github authtoken must be specified for this test (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)")
     def test_installDeps(self):
         with open(os.path.join(Test_Dir, 'module.json'), 'w') as f:
             f.write(Test_Module_JSON)

--- a/yotta/test/github_access.py
+++ b/yotta/test/github_access.py
@@ -24,10 +24,11 @@ Test_Deps_Name = "autopulated/github-access-testing"
 Test_Branch_Name = "autopulated/github-access-testing#master"
 Test_Deps_Target = "x86-osx-native,*"
 
-def ensureGithubConfig():
-    # ensure we have authentication for the test github account
+def hasGithubConfig():
+    # can't run tests that hit github without an authn token
     if not settings.getProperty('github', 'authtoken'):
-        raise Exception('a github authtoken must be specified in the environment (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)')
+        return False
+    return True
 
 class TestGitHubAccess(unittest.TestCase):
     def setUp(self):
@@ -36,10 +37,12 @@ class TestGitHubAccess(unittest.TestCase):
     def tearDown(self):
         pass
 
+    @unittest.skipIf(not hasGithubConfig(), "a github authtoken must be specified for this test (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)")
     def test_installDeps(self):
         Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'save', 'save_target'])
         install.installComponent(Args(Test_Deps_Name, Test_Deps_Target, False, False, False, False))
 
+    @unittest.skipIf(not hasGithubConfig(), "a github authtoken must be specified for this test (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)")
     def test_branchAccess(self):
         Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'save', 'save_target'])
         install.installComponent(Args(Test_Branch_Name, Test_Deps_Target, False, False, False, False))

--- a/yotta/test/github_access.py
+++ b/yotta/test/github_access.py
@@ -23,14 +23,11 @@ Test_Name = 'testing-dummy'
 Test_Deps_Name = "autopulated/github-access-testing"
 Test_Branch_Name = "autopulated/github-access-testing#master"
 Test_Deps_Target = "x86-osx-native,*"
-Test_Username = 'yottatest'
-Test_Access_Token = 'c53aadbd89caefdcadb0d43d18ef863e1d9cbcf4'
 
 def ensureGithubConfig():
     # ensure we have authentication for the test github account
     if not settings.getProperty('github', 'authtoken'):
-        settings.setProperty('github', 'authtoken', Test_Access_Token)
-
+        raise Exception('a github authtoken must be specified in the environment (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)')
 
 class TestGitHubAccess(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
I've added an authtoken for @yottatest to the travis CI setup, so the tests should pass again now.