### PR TITLE
use json to store settings

### DIFF
--- a/yotta/install.py
+++ b/yotta/install.py
@@ -15,7 +15,7 @@ from .lib import component
 from .lib import access
 
 # folders, , get places to install things, internal
-from . import folders
+from .lib import folders
 
 GitHub_Ref_RE = re.compile('[a-zA-Z0-9-]*/([a-zA-Z0-9-]*)')
 

--- a/yotta/lib/folders.py
+++ b/yotta/lib/folders.py
@@ -16,21 +16,22 @@
 # standard library modules, , ,
 import os
 # fsutils, , misc filesystem utils, internal
-from .lib import fsutils
+import fsutils
+
+def prefix():
+    if 'YOTTA_PREFIX' in os.environ:
+        return os.environ['YOTTA_PREFIX']
+    else:
+        if os.name == 'nt':
+            dirname = os.path.join(os.getenv("PROGRAMFILES"), "yotta")
+            fsutils.mkDirP(dirname)
+            return dirname
+        else:
+            return '/usr/local'
 
 def globalInstallDirectory():
-    if os.name == 'nt':
-        dirname = os.path.join(os.getenv("PROGRAMFILES"), "yotta", "yotta_modules")
-        fsutils.mkDirP(dirname)
-        return dirname
-    else:
-        return '/usr/local/lib/yotta_modules'
+    return os.path.join(prefix(), 'lib', 'yotta_modules')
 
 def globalTargetInstallDirectory():
-    if os.name == 'nt':
-        dirname = os.path.join(os.getenv("PROGRAMFILES"), "yotta", "yotta_targets")
-        fsutils.mkDirP(dirname)
-        return dirname
-    else:
-        return '/usr/local/lib/yotta_targets'
+    return os.path.join(prefix(), 'lib', 'yotta_targets')
 

--- a/yotta/lib/folders.py
+++ b/yotta/lib/folders.py
@@ -30,8 +30,14 @@ def prefix():
             return '/usr/local'
 
 def globalInstallDirectory():
-    return os.path.join(prefix(), 'lib', 'yotta_modules')
+    if os.name == 'nt':
+        return os.path.join(prefix(), 'yotta_modules')
+    else:
+        return os.path.join(prefix(), 'lib', 'yotta_modules')
 
 def globalTargetInstallDirectory():
-    return os.path.join(prefix(), 'lib', 'yotta_targets')
+    if os.name == 'nt':
+        return os.path.join(prefix(), 'yotta_targets')
+    else:
+        return os.path.join(prefix(), 'lib', 'yotta_targets')
 

--- a/yotta/lib/settings.py
+++ b/yotta/lib/settings.py
@@ -13,6 +13,8 @@ from collections import OrderedDict
 import fsutils
 # Ordered JSON, , read & write json, internal
 import ordered_json
+# folders, , get places to install things, internal
+import folders
 
 #
 # yotta's settings always written to ~/.yotta/config.json, but are read, in
@@ -27,17 +29,13 @@ import ordered_json
 #
 #
 
-if 'YOTTA_PREFIX' in os.environ:
-    path_prefix = os.environ['YOTTA_PREFIX']
-else:
-    path_prefix = '/usr/local'
-
 # constants
 user_config_file = os.path.expanduser('~/.yotta/config.json')
 
 config_files = [
+    os.path.join('.','.yottaconfig'),
     user_config_file,
-    os.path.expanduser(os.path.join(path_prefix, 'etc','yottaconfig.json')),
+    os.path.expanduser(os.path.join(folders.prefix(), 'etc','yottaconfig.json')),
     '/etc/yottaconfig.json'
 ]
 

--- a/yotta/lib/settings.py
+++ b/yotta/lib/settings.py
@@ -114,7 +114,7 @@ class _JSONConfigParser(object):
     
     def write(self, filename=None):
         if filename is None:
-            filename, data = _firstConfig()
+            filename, data = self._firstConfig()
         elif filename in self.configs:
             data = self.configs[filename]
         else:
@@ -135,8 +135,6 @@ class _JSONConfigParser(object):
         if not len(path):
             raise ValueError('A path must be specified.')
         return r
-        
-
 
 def _ensureParser():
     global parser

--- a/yotta/lib/validate.py
+++ b/yotta/lib/validate.py
@@ -38,7 +38,7 @@ def sourceDirValidationError(dirname, component_name):
 
 def componentNameValidationError(component_name):
     if not Component_Name_Regex.match(component_name):
-        return 'Module name "%s" is invalid - must contain only lowercase a-z, 0-9 and hyphen, with no spaces.'
+        return 'Module name "%s" is invalid - must contain only lowercase a-z, 0-9 and hyphen, with no spaces.' % component_name
     return None
 
 def componentNameCoerced(component_name):

--- a/yotta/link.py
+++ b/yotta/link.py
@@ -17,7 +17,7 @@ from .lib import fsutils
 # validate, , validate things, internal
 from .lib import validate
 # folders, , get places to install things, internal
-from . import folders
+from .lib import folders
 # install, , install subcommand, internal
 from . import install
 

--- a/yotta/link_target.py
+++ b/yotta/link_target.py
@@ -17,7 +17,7 @@ from .lib import target
 # fsutils, , misc filesystem utils, internal
 from .lib import fsutils
 # folders, , get places to install things, internal
-from . import folders
+from .lib import folders
 
 def addOptions(parser):
     parser.add_argument('target', default=None, nargs='?',

--- a/yotta/test/settings.py
+++ b/yotta/test/settings.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# Copyright 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+
+# standard library modules, , ,
+import unittest
+import tempfile
+import os
+
+# validate, , validate various things, internal
+from yotta.lib import settings
+from yotta.lib.fsutils import rmRf
+
+class TestSettings(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp() 
+        test_files = [
+            ('1.json', '{"a":{"b":{"c":"1-value"}}}'),
+            ('2.json', '{"a":{"b":{"c":"2-value"}, "b2":"2-value"}}'),
+            ('3.json', '{"a":{"b":{"c":"3-value"}, "b2":"3-value"}, "a2":"3-value"}')
+        ]
+        self.filenames = []
+        for fn, s in test_files:
+            self.filenames.append(os.path.join(self.test_dir, fn))
+            with open(self.filenames[-1], 'w') as f:
+                f.write(s)
+
+    def tearDown(self):
+        rmRf(self.test_dir)
+
+    def test_merging(self):
+        p = settings._JSONConfigParser()
+        p.read(self.filenames)
+        self.assertEqual(p.get('a.b.c'), '1-value')
+        self.assertEqual(p.get('a.b2'), '2-value')
+        self.assertEqual(p.get('a2'), '3-value')
+
+    def test_setting(self):
+        p = settings._JSONConfigParser()
+        p.read(self.filenames)
+
+        p.set('foo', 'xxx')
+        self.assertEqual(p.get('foo'), 'xxx')
+
+        p.set('someLongNameHere_etc_etc', 'xxx')
+        self.assertEqual(p.get('someLongNameHere_etc_etc'), 'xxx')
+
+        p.set('someLongNameHere_etc_etc.with.a.path', True, filename=self.filenames[1])
+        self.assertEqual(p.get('someLongNameHere_etc_etc.with.a.path'), True)
+
+        p.set('someLongNameHere_etc_etc.with.a.path', False, filename=self.filenames[1])
+        self.assertEqual(p.get('someLongNameHere_etc_etc.with.a.path'), False)
+
+        # NB: don't expect it to change when we set a value that's shadowed by
+        # an earlier file:
+        p.set('someLongNameHere_etc_etc.with.a.path', 7, filename=self.filenames[2])
+        self.assertEqual(p.get('someLongNameHere_etc_etc.with.a.path'), False)
+
+        p.set('someLongNameHere_etc_etc.with.another.path', 7, filename=self.filenames[2])
+        self.assertEqual(p.get('someLongNameHere_etc_etc.with.another.path'), 7)
+
+
+    def test_writing(self):
+        p = settings._JSONConfigParser()
+        p.read(self.filenames)
+
+        p.set('foo', 'xxx')
+        p.set('someLongNameHere_etc_etc', 'xxx')
+        p.set('someLongNameHere_etc_etc.with.a.path', True, filename=self.filenames[1])
+        p.set('someLongNameHere_etc_etc.with.a.path', False, filename=self.filenames[1])
+        p.set('someLongNameHere_etc_etc.with.a.path', 7, filename=self.filenames[2])
+        p.set('someLongNameHere_etc_etc.with.another.path', 7, filename=self.filenames[2])
+        
+        # NB: only write settings to the first file
+        p.write()
+
+        self.assertEqual(p.get('foo'), 'xxx')
+        self.assertEqual(p.get('someLongNameHere_etc_etc'), 'xxx')
+        self.assertEqual(p.get('someLongNameHere_etc_etc.with.a.path'), False)
+        self.assertEqual(p.get('someLongNameHere_etc_etc.with.another.path'), 7)
+
+        p2 = settings._JSONConfigParser()
+        p2.read(self.filenames)
+        self.assertEqual(p2.get('foo'), 'xxx')
+        self.assertEqual(p2.get('someLongNameHere_etc_etc'), 'xxx')
+
+        # check that we only wrote settings to the first file
+        self.assertEqual(p2.get('someLongNameHere_etc_etc.with.a.path'), None)
+
+        # now write settings for the other files, and continue
+        p.write(self.filenames[1])
+        p.write(self.filenames[2])
+
+        p3 = settings._JSONConfigParser()
+        p3.read(self.filenames)
+        self.assertEqual(p3.get('someLongNameHere_etc_etc.with.a.path'), False)
+        self.assertEqual(p3.get('someLongNameHere_etc_etc.with.another.path'), 7)
+
+
+        p4 = settings._JSONConfigParser()
+        p4.read([self.filenames[1]])
+        self.assertEqual(p4.get('foo'), None)
+        self.assertEqual(p4.get('someLongNameHere_etc_etc.with.a.path'), False)
+        self.assertEqual(p4.get('someLongNameHere_etc_etc.with.another.path'), None)
+
+        p5 = settings._JSONConfigParser()
+        p5.read([self.filenames[2]])
+        self.assertEqual(p5.get('foo'), None)
+        self.assertEqual(p5.get('someLongNameHere_etc_etc.with.a.path'), 7)
+        self.assertEqual(p5.get('someLongNameHere_etc_etc.with.another.path'), 7)
+
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+
+

--- a/yotta/uninstall.py
+++ b/yotta/uninstall.py
@@ -23,7 +23,7 @@ def addOptions(parser):
 def execCommand(args, following_args):
     err = validate.componentNameValidationError(args.component)
     if err:
-        logger.error(err)
+        logging.error(err)
         return 1
     c = validate.currentDirectoryModule()
     if not c:


### PR DESCRIPTION
This will allow more complex settings information (e.g. lists of things) to be stored in the future.

Note that this change will discard any existing settings (target name, and authentication information), so you may have to login again (or you can manually transfer your settings from `~/.yotta/config` to `~/.yotta/config.json` if you'd prefer.)

Example of a config.json file:
```json
{
  "build": {
    "target": "x86-linux-native,*"
  },
  "keys": {
    "private": "abcdef",
    "public": "abcdef"
  },
  "github": {
    "authtoken": "abcdef"
  }
}

```
