### PR TITLE
Save the target in the current directory.

### DIFF
--- a/yotta/lib/settings.py
+++ b/yotta/lib/settings.py
@@ -36,9 +36,17 @@ dir_config_file = os.path.join('.','.yotta.json')
 config_files = [
     dir_config_file,
     user_config_file,
-    os.path.expanduser(os.path.join(folders.prefix(), 'etc','yottaconfig.json')),
-    '/etc/yottaconfig.json'
 ]
+if os.name == 'nt':
+    config_files += [
+        os.path.expanduser(os.path.join(folders.prefix(),'yotta.json'))
+    ]
+else:
+    config_files += [
+        os.path.expanduser(os.path.join(folders.prefix(),'etc','yotta.json')),
+        os.path.join('etc','yotta.json')
+    ]
+
 
 # private state
 parser = None

--- a/yotta/lib/settings.py
+++ b/yotta/lib/settings.py
@@ -31,9 +31,10 @@ import folders
 
 # constants
 user_config_file = os.path.expanduser('~/.yotta/config.json')
+dir_config_file = os.path.join('.','.yotta.json')
 
 config_files = [
-    os.path.join('.','.yottaconfig'),
+    dir_config_file,
     user_config_file,
     os.path.expanduser(os.path.join(folders.prefix(), 'etc','yottaconfig.json')),
     '/etc/yottaconfig.json'
@@ -158,17 +159,16 @@ def getProperty(section, name):
     with parser_lock:
         return parser.get('.'.join([section, name]))
 
-def getArray(path):
-    pass
+def setProperty(section, name, value, save_locally=False):
+    if save_locally:
+        filename = dir_config_file
+    else:
+        filename = user_config_file
 
-def setArray(path, value):
-    pass
-
-def setProperty(section, name, value):
     logging.debug('setProperty: %s:%s %s:%s', type(name), name, type(value), value)
     # use a local parser instance so that we don't copy system-wide settings
     # into the user config file
     with parser_lock:
-        parser.set('.'.join([section, name]), value=value, filename=user_config_file)
-        parser.write(user_config_file)
+        parser.set('.'.join([section, name]), value=value, filename=filename)
+        parser.write(filename)
 

--- a/yotta/target.py
+++ b/yotta/target.py
@@ -25,6 +25,10 @@ def addOptions(parser):
     parser.add_argument('set_target', default=None, nargs='?',
         help='set the build target to this (targetname[,versionspec_or_url])'
     )
+    parser.add_argument('-g', '--global', dest='save_global',
+        default=False, action='store_true',
+        help='set globally (in the per-user settings) instead of locally to this directory'
+    )
 
     # FIXME: need help that lists possible targets, and we need a walkthrough
     # guide to forking a new target for an existing board
@@ -65,4 +69,4 @@ def execCommand(args, following_args):
                 target = args.set_target + ',*'
             else:
                 target = args.set_target
-            settings.setProperty('build', 'target', target)
+            settings.setProperty('build', 'target', target, not args.save_global)


### PR DESCRIPTION
 * is this desired behaviour?
 * is `.yotta.json` the right filename for this? Or should it be something else, like `.yotta/config.json`, or `.yottaconfig.json`?
 * how should dot files be handled on windows-y systems?

(note that this pull request is predicated on json-settings, and includes the commits from there)