### PR TITLE
Using standard python prefix for yotta_modules and yotta_targets

### DIFF
--- a/yotta/lib/folders.py
+++ b/yotta/lib/folders.py
@@ -3,18 +3,13 @@
 # Licensed under the Apache License, Version 2.0
 # See LICENSE file for details.
 
-# !!! FIXME: on Windows, this creates a "yotta" directory under Program Files and
-# links there. Needs to be fixed (how?)
-
-# !!! FIXME: "PROGRAMFILES" env variable might exist only on Windows 7 and above.
-# Needs testing on other Windows systems
-
 # !!! FIXME: there are now multiple .py files that contain platform dependent
 # code and conditions such as 'if os.name == "nt"' Ideally, all these platform
 # dependent function would live in an OS abstraction module
 
 # standard library modules, , ,
 import os
+import sys
 # fsutils, , misc filesystem utils, internal
 import fsutils
 
@@ -22,21 +17,16 @@ def prefix():
     if 'YOTTA_PREFIX' in os.environ:
         return os.environ['YOTTA_PREFIX']
     else:
-        if os.name == 'nt':
-            dirname = os.path.join(os.getenv("PROGRAMFILES"), "yotta")
-            return dirname
-        else:
-            return '/usr/local'
+        return sys.exec_prefix
 
 def globalInstallDirectory():
     if os.name == 'nt':
-        return os.path.join(prefix(), 'yotta_modules')
+        return os.path.join(prefix(), 'Lib', 'yotta_modules')
     else:
         return os.path.join(prefix(), 'lib', 'yotta_modules')
 
 def globalTargetInstallDirectory():
     if os.name == 'nt':
-        return os.path.join(prefix(), 'yotta_targets')
+        return os.path.join(prefix(), 'Lib', 'yotta_targets')
     else:
         return os.path.join(prefix(), 'lib', 'yotta_targets')
-


### PR DESCRIPTION
This pr addresses the ```prefix()``` function in ```folders.py``` for portability and use of virtual environments.

The ```sys``` module [provides](https://docs.python.org/2/install/#how-installation-works) ```prefix``` and ```exec_prefix``` for the installation of 3rd-party modules. By using them, ```prefix()``` still returns ```/usr/local``` on \*nix platforms. On Windows, it returns ```C:\Python27``` (maybe addressing one of the ```FIXME```?) \*

Besides portability, this approach allows sandboxed development through virtual environments. A link to a local yotta module is only valid in the active environment (virtual or not) and not necessarily system wide. 

Use case:
```bash
$ mkdir ~/dev_env
$ virtualenv ~/dev_env
$ cd ~/dev_env && source bin/activate
(dev_env) $ pip install yotta
...
(dev_env) $ git clone yt_module && cd yt_module
(dev_env) $ yt link
```
The net result is that the symbolic link to yt_module is now in ```~/dev_env/lib/yotta_modules``` and not in ```/usr/local/lib/yotta_modules``` (\*nix). The latter path still applies outside the virtual environment.

(loosely) Tested with OS X (10.9), Linux (Ubuntu 14.10), and Windows 7.

<sub> \* (I don't know if ```PROGRAMFILES``` was used in the first place in Windows for a specific reason -- apologies) <sub>