### PR TITLE
Updated docs to reflect current Ubuntu package issues with gcc-arm

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -163,8 +163,28 @@ the native compiler.
 ### Cross-compiling from Linux
 
 First install the [`arm-none-eabi-gcc`
-compiler](https://launchpad.net/gcc-arm-embedded):
+compiler](https://launchpad.net/gcc-arm-embedded).
 
+#### Ubuntu 14.04 or later users:
+There is a package name conflict for [Ubuntu 14.04 and later](https://launchpad.net/~terry.guo/+archive/ubuntu/gcc-arm-embedded).
+Remove previous versions and update your repositories:
+```sh
+sudo apt-get remove binutils-arm-none-eabi gcc-arm-none-eabi
+sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded
+sudo apt-get update
+```
+
+Install the compiler package for Ubuntu 14.04:
+```sh
+sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q1-0trusty13
+```
+
+or for Ubuntu 14.10:
+```sh
+    sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q1-0utopic14
+```
+
+#### All other Linux users:
 ```sh
 sudo apt-get install gcc-arm-none-eabi
 ```
@@ -216,7 +236,7 @@ target, such as
     uses. Download the release archive from the [releases
     page](https://github.com/martine/ninja/releases/download/v1.5.3/ninja-win.zip),
     and extract it to a directory (for example `C:\ninja`).
- 
+
  5. Add the directory you installed Ninja in to [your path](#windows-path).
 
  6. Install the **[arm-none-eabi-gcc](#windows-cross-compile) cross-compiler** in


### PR DESCRIPTION
I ran into this issue when trying to get yotta running on Ubuntu 14.04 64bit. Under the section [Cross-compiling from Linux](http://docs.yottabuild.org/#installing-on-linux) in the yotta docs, the following command is given:
```sh
sudo apt-get install gcc-arm-none-eabi
```

If you run this command in Ubuntu 14.04, it installs an outdated version of the compiler. When building with yotta I ran into errors like this:
```
/path/to/file.h: fatal error: cstddef: No such file or directory
 #include <cstddef>
                   ^
compilation terminated.
...
make: *** [all] Error 2
error: command ['make'] failed
```

You have to use a different repository for Ubuntu 14.04 later, as detailed on [this page](https://launchpad.net/~terry.guo/+archive/ubuntu/gcc-arm-embedded) from the [GNU Tools for ARM Embedded Processors launchpad page](https://launchpad.net/gcc-arm-embedded).

This allowed yotta to build without errors. I've proposed a change to the docs for now until all the packages get squared away. Feel free to edit as you see fit, but this issue should probably be mentioned because this is a show-stopper for those who are not familiar with the toolchain.