### PR TITLE
replace pycrypto with cryptography

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -192,37 +192,24 @@ target, such as
     **During installation, be sure to select the "add to path" option.** This
     will let you run python easily from a command prompt.
 
- 2. Install PyCrypto 2.6 for Python 2.7 from
-    [Voidspace](http://www.voidspace.org.uk/python/modules.shtml#pycrypto).
-    Select either the [32-bit
-    installer](http://www.voidspace.org.uk/downloads/pycrypto26/pycrypto-2.6.win32-py2.7.exe)
-    or the [64-bit
-    installer](http://www.voidspace.org.uk/downloads/pycrypto26/pycrypto-2.6.win-amd64-py2.7.exe)
-    matching the python version that you installed.
-
-    If pip cannot be found, you need to add the python scripts directory to
-    your path. This is `C:\Python27\Scripts` unless you selected a different
-    directory during python installation. [These instructions](#windows-path)
-    will guide you through the process.
-
- 3. **Install [CMake](http://www.cmake.org/download/)**. yotta uses CMake to
+ 2. **Install [CMake](http://www.cmake.org/download/)**. yotta uses CMake to
     generate makefiles that control the build. Select the latest available
     version, currently 3.2.1 The [32-bit
     version](http://www.cmake.org/files/v3.2/cmake-3.2.1-win32-x86.exe)
     will work on all versions of windows. Be sure to check the "add cmake to
     the path for current user" option during installation.
 
- 4. **Install Ninja**, the small and extremely fast build system that yotta
+ 3. **Install Ninja**, the small and extremely fast build system that yotta
     uses. Download the release archive from the [releases
     page](https://github.com/martine/ninja/releases/download/v1.5.3/ninja-win.zip),
     and extract it to a directory (for example `C:\ninja`).
  
- 5. Add the directory you installed Ninja in to [your path](#windows-path).
+ 4. Add the directory you installed Ninja in to [your path](#windows-path).
 
- 6. Install the **[arm-none-eabi-gcc](#windows-cross-compile) cross-compiler** in
+ 5. Install the **[arm-none-eabi-gcc](#windows-cross-compile) cross-compiler** in
     order to build software to run on embedded devices.
 
- 7. Finally, **open cmd.exe and run `pip install -U yotta`** to install yotta
+ 6. Finally, **open cmd.exe and run `pip install -U yotta`** to install yotta
     itself.
 
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'hgapi>=1.7,<2',
         'Jinja2>=2.7.0,<3',
         'cryptography>=0.8',
-        'PyJWT>=0.3,<0.4',
+        'PyJWT>=1.0,<2.0',
         'pathlib>=1.0.1,<1.1',
         'jsonschema>=2.4.0,<3.0',
         'valinor>=0.0.0,<1.0'

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,11 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-# On Windows, fix the version of PyCrypto dependency to 2.6, so we can use
-# the binary installer from voidspace.org.uk (otherwise pip tries to install
-# a newer pycrypto from PyPI). Also, we need 'ntfsutils' in Windows
+# we need 'ntfsutils' in Windows
 if os.name == 'nt':
     platform_deps = ['ntfsutils>=0.1.3,<0.2']
-    pycrypto_dep = 'PyCrypto==2.6'
 else:
     platform_deps = []
-    pycrypto_dep = 'PyCrypto>=2.5,<3'
 
 setup(
     name = "yotta",
@@ -54,7 +50,7 @@ setup(
         'colorama>=0.3,<0.4',
         'hgapi>=1.7,<2',
         'Jinja2>=2.7.0,<3',
-        pycrypto_dep,
+        'cryptography>=0.8',
         'PyJWT>=0.3,<0.4',
         'pathlib>=1.0.1,<1.1',
         'jsonschema>=2.4.0,<3.0',

--- a/yotta/lib/exportkey.py
+++ b/yotta/lib/exportkey.py
@@ -57,10 +57,6 @@ def long_to_bytes(n, blocksize=0):
 def openSSH(pubkey):
     e = long_to_bytes(pubkey.e)
     n = long_to_bytes(pubkey.n)
-    print 'e:', pubkey.e
-    print 'n:', pubkey.n
-    print 'e bytes:', len(e), binascii.hexlify(e)
-    print 'n bytes:', len(n), binascii.hexlify(n)
 
     if bord(e[0]) & 0x80:
         e = bchr(0) + e

--- a/yotta/lib/exportkey.py
+++ b/yotta/lib/exportkey.py
@@ -11,11 +11,6 @@ import struct
 import binascii
 import sys
 
-# pycrypto, Public Domain, Python Crypto Library, pip install pyCRypto
-import Crypto
-from Crypto.Util.number import long_to_bytes
-
-
 if sys.version_info[0] == 3:
     def bord(x):
         return x
@@ -28,10 +23,44 @@ elif sys.version_info[0] == 2:
     def bchr(x):
         return chr(x)
 
+# long_to_bytes: from PyCrypto (public domain)
+def long_to_bytes(n, blocksize=0):
+    """long_to_bytes(n:long, blocksize:int) : string
+    Convert a long integer to a byte string.
+
+    If optional blocksize is given and greater than zero, pad the front of the
+    byte string with binary zeros so that the length is a multiple of
+    blocksize.
+    """
+    # after much testing, this algorithm was deemed to be the fastest
+    s = ''
+    n = long(n)
+    pack = struct.pack
+    while n > 0:
+        s = pack('>I', n & 0xffffffffL) + s
+        n = n >> 32
+    # strip off leading zeros
+    for i in range(len(s)):
+        if s[i] != '\000':
+            break
+    else:
+        # only happens when n == 0
+        s = '\000'
+        i = 0
+    s = s[i:]
+    # add back some pad bytes.  this could be done more efficiently w.r.t. the
+    # de-padding being done above, but sigh...
+    if blocksize > 0 and len(s) % blocksize:
+        s = (blocksize - len(s) % blocksize) * '\000' + s
+    return s
 
 def openSSH(pubkey):
     e = long_to_bytes(pubkey.e)
     n = long_to_bytes(pubkey.n)
+    print 'e:', pubkey.e
+    print 'n:', pubkey.n
+    print 'e bytes:', len(e), binascii.hexlify(e)
+    print 'n bytes:', len(n), binascii.hexlify(n)
 
     if bord(e[0]) & 0x80:
         e = bchr(0) + e

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -27,9 +27,11 @@ import requests
 
 # PyJWT, MIT, Jason Web Tokens, pip install PyJWT
 import jwt
-# pycrypto, Public Domain, Python Crypto Library, pip install pyCRypto
-import Crypto
-from Crypto.PublicKey import RSA
+# cryptography, Apache License, Python Cryptography library, 
+import cryptography
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
 
 # settings, , load and save settings, internal
 import settings
@@ -58,7 +60,7 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 
 def generate_jwt_token(private_key):
     expires = calendar.timegm((datetime.datetime.utcnow() + datetime.timedelta(hours=2)).timetuple())
-    prn = _fingerprint(private_key.publickey())
+    prn = _fingerprint(private_key.public_key())
     logger.debug('fingerprint: %s' % prn)
     token_fields = {
         "iss": 'yotta',
@@ -67,16 +69,23 @@ def generate_jwt_token(private_key):
         "exp": str(expires)
     }
     logger.debug('token fields: %s' % token_fields)
-    token = jwt.encode(token_fields, private_key, 'RS256').decode('ascii')
+    private_key_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption()
+    )
+    token = jwt.encode(token_fields, private_key_pem, 'RS256').decode('ascii')
     logger.debug('encoded token: %s' % token)
 
     return token
 
 def _pubkeyWireFormat(pubkey):
-    return quoteURL(_OpenSSH_Keyfile_Strip.sub(b'', exportkey.openSSH(pubkey)))
+    pubk_numbers = pubkey.public_numbers()
+    logger.debug('openssh format publickey:\n%s' % exportkey.openSSH(pubk_numbers))
+    return quoteURL(_OpenSSH_Keyfile_Strip.sub(b'', exportkey.openSSH(pubk_numbers)))
 
 def _fingerprint(pubkey):
-    stripped = _OpenSSH_Keyfile_Strip.sub(b'', exportkey.openSSH(pubkey))
+    stripped = _OpenSSH_Keyfile_Strip.sub(b'', exportkey.openSSH(pubkey.public_numbers()))
     decoded  = base64.b64decode(stripped)
     khash    = hashlib.md5(decoded).hexdigest()
     return ':'.join([khash[i:i+2] for i in range(0, len(khash), 2)])
@@ -179,18 +188,42 @@ def _getTarball(url, directory, sha256):
     return access_common.unpackTarballStream(response, directory, ('sha256', sha256))
 
 def _generateAndSaveKeys():
-    k = RSA.generate(2048)
-    privatekey_hex = binascii.hexlify(k.exportKey('DER')).decode('ascii')
-    settings.setProperty('keys', 'private', privatekey_hex)
-    pubkey_hex = binascii.hexlify(k.publickey().exportKey('DER')).decode('ascii')
-    settings.setProperty('keys', 'public', pubkey_hex)
-    return pubkey_hex, privatekey_hex
+    k = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    privatekey_pem = k.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption()
+    )
+    settings.setProperty('keys', 'private', privatekey_pem)
+
+    pubkey_pem = k.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    settings.setProperty('keys', 'public', pubkey_pem)
+    return pubkey_pem, privatekey_pem
 
 def _getPrivateKeyObject():
-    privatekey_hex =  settings.getProperty('keys', 'private')
-    if not privatekey_hex:
-        pubkey_hex, privatekey_hex = _generateAndSaveKeys()
-    return RSA.importKey(binascii.unhexlify(privatekey_hex))
+    privatekey_pem =  settings.getProperty('keys', 'private')
+    if not privatekey_pem:
+        pubkey_pem, privatekey_pem = _generateAndSaveKeys()
+    else:
+        # settings are unicode, we should be able to safely decode to ascii for
+        # the key though, as it will either be hex or PEM encoded:
+        privatekey_pem = privatekey_pem.encode('ascii')
+    # if the key doesn't look like PEM, it might be hex-encided-DER (which we
+    # used historically), so try loading that:
+    if '-----BEGIN PRIVATE KEY-----' in privatekey_pem:
+        return serialization.load_pem_private_key(
+            privatekey_pem, None, default_backend()
+        )
+    else:
+        privatekey_der = binascii.unhexlify(privatekey_pem)
+        return serialization.load_der_private_key(
+            privatekey_der, None, default_backend()
+        )
 
 # API
 class RegistryThingVersion(access_common.RemoteVersion):
@@ -418,14 +451,22 @@ def deauthorize():
 
 def getPublicKey():
     ''' Return the user's public key (generating and saving a new key pair if necessary) '''
-    pubkey_hex = settings.getProperty('keys', 'public')
-    if not pubkey_hex:
-        k = RSA.generate(2048)
-        settings.setProperty('keys', 'private', binascii.hexlify(k.exportKey('DER')))
-        pubkey_hex = binascii.hexlify(k.publickey().exportKey('DER'))
-        settings.setProperty('keys', 'public', pubkey_hex)
-        pubkey_hex, privatekey_hex = _generateAndSaveKeys()
-    return _pubkeyWireFormat(RSA.importKey(binascii.unhexlify(pubkey_hex)))
+    pubkey_pem = settings.getProperty('keys', 'public')
+    if not pubkey_pem:
+        pubkey_pem, privatekey_pem = _generateAndSaveKeys()
+    else:
+        # settings are unicode, we should be able to safely decode to ascii for
+        # the key though, as it will either be hex or PEM encoded:
+        pubkey_pem = pubkey_pem.encode('ascii')
+    # if the key doesn't look like PEM, it might be hex-encided-DER (which we
+    # used historically), so try loading that:
+    if '-----BEGIN PUBLIC KEY-----' in pubkey_pem:
+        pubkey = serialization.load_pem_public_key(pubkey_pem, default_backend())
+    else:
+        pubkey_der = binascii.unhexlify(pubkey_pem)        
+        pubkey = serialization.load_der_public_key(pubkey_der, default_backend())
+    return _pubkeyWireFormat(pubkey)
+
 
 def testLogin():
     url = '%s/users/me' % (


### PR DESCRIPTION
Now saves keys in PEM format instead of hex-encoded DER. (Will still read keys previously saved as DER).

This should make the windows installation process simpler!