### PR TITLE
present more friendly errors if components are unavailable

### DIFF
--- a/yotta/install.py
+++ b/yotta/install.py
@@ -13,6 +13,8 @@ import re
 from .lib import component
 # access, , get components, internal
 from .lib import access
+# access, , get components, internal
+from .lib import access_common
 
 # folders, , get places to install things, internal
 from .lib import folders
@@ -108,24 +110,30 @@ def installComponentAsDependency(args, current_component):
     # below), for these the original source should be included in the version
     # spec, too
     github_ref_match = GitHub_Ref_RE.match(args.component)
-    if github_ref_match:
-        component_name = github_ref_match.group(1)
-        installed = access.satisfyVersion(
-                component_name,
-                args.component,
-                     available = {current_component.getName():current_component},
-                  search_paths = [modules_dir],
-             working_directory = modules_dir
-        )
-    else:
-        component_name = args.component
-        installed = access.satisfyVersion(
-                component_name,
-                           '*',
-                     available = {current_component.getName():current_component},
-                  search_paths = [modules_dir],
-             working_directory = modules_dir
-        )
+    try:
+        if github_ref_match:
+            component_name = github_ref_match.group(1)
+            installed = access.satisfyVersion(
+                    component_name,
+                    args.component,
+                         available = {current_component.getName():current_component},
+                      search_paths = [modules_dir],
+                 working_directory = modules_dir
+            )
+        else:
+            component_name = args.component
+            installed = access.satisfyVersion(
+                    component_name,
+                               '*',
+                         available = {current_component.getName():current_component},
+                      search_paths = [modules_dir],
+                 working_directory = modules_dir
+            )
+    except access_common.ComponentUnavailable as e:
+        logging.error(e)
+        return 1
+
+
     # always add the component to the dependencies of the current component
     # - but don't write the dependency file back to disk if we're not meant to
     # save it

--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -109,7 +109,7 @@ def latestSuitableVersion(name, version_required, registry='modules'):
         v = spec.select(vers)
         logger.debug("%s selected %s from %s", spec, v, vers)
         if not v:
-            raise Exception(
+            raise access_common.ComponentUnavailable(
                 'The %s registry does not provide a version of "%s" matching "%s"' % (
                     registry, name, spec
                 )
@@ -130,7 +130,7 @@ def latestSuitableVersion(name, version_required, registry='modules'):
             v = spec.select(vers)
             logger.debug("%s selected %s from %s", spec, v, vers)
             if not v:
-                raise Exception(
+                raise access_common.ComponentUnavailable(
                     'Github repository "%s" does not provide a version matching "%s"' % (
                         remote_component.repo,
                         remote_component.spec
@@ -147,7 +147,7 @@ def latestSuitableVersion(name, version_required, registry='modules'):
             )
             if v:
                 return v
-            raise Exception(
+            raise access_common.ComponentUnavailable(
                 'Github repository "%s" does not have any tags or branches matching "%s"' % (
                     version_required, spec
                 )
@@ -158,7 +158,7 @@ def latestSuitableVersion(name, version_required, registry='modules'):
         logger.debug('satisfy %s from %s url' % (name, clone_type))
         local_clone = remote_component.clone()
         if not local_clone:
-            raise Exception(
+            raise access_common.ComponentUnavailable(
                 'Failed to clone %s URL %s to satisfy dependency %s' % (clone_type, version_required, name)
             )
         spec = remote_component.versionSpec()
@@ -172,7 +172,7 @@ def latestSuitableVersion(name, version_required, registry='modules'):
             v = spec.select(vers)
             logger.debug("%s selected %s from %s", spec, v, vers)
             if not v:
-                raise Exception(
+                raise access_common.ComponentUnavailable(
                     '%s repository "%s" does not provide a version matching "%s"' % (
                         clone_type,
                         version_required,
@@ -189,7 +189,7 @@ def latestSuitableVersion(name, version_required, registry='modules'):
             )
             if v:
                 return v
-            raise Exception(
+            raise access_common.ComponentUnavailable(
                 '%s repository "%s" does not have any tags or branches matching "%s"' % (
                     clone_type, version_required, spec
                 )
@@ -230,9 +230,9 @@ def satisfyVersionFromAvailble(name, version_required, available):
                 ) 
         r = available[name]
         if spec and not spec.match(r.getVersion()):
-            raise Exception('Previously added component %s@%s doesn\'t meet spec %s' % (name, r.getVersion(), spec))
+            raise access_common.ComponentUnavailable('Previously added component %s@%s doesn\'t meet spec %s' % (name, r.getVersion(), spec))
         if name != r.getName():
-            raise Exception('Component %s was installed as different name %s in %s' % (
+            raise access_common.ComponentUnavailable('Component %s was installed as different name %s in %s' % (
                 r.getName(), name, r.path
             ))
         return r


### PR DESCRIPTION
(stack traces are for internal errors, not errors that can be caused by external data)