### PR TITLE
Python 3 fixes

### DIFF
--- a/yotta/lib/exportkey.py
+++ b/yotta/lib/exportkey.py
@@ -37,7 +37,7 @@ def long_to_bytes(n, blocksize=0):
     n = long(n)
     pack = struct.pack
     while n > 0:
-        s = pack('>I', n & 0xffffffffL) + s
+        s = pack('>I', n & 0xffffffff) + s
         n = n >> 32
     # strip off leading zeros
     for i in range(len(s)):


### PR DESCRIPTION
don't use L suffix, it has no effect here, and is invalid in python3; remove some causes of different build order between python 2 and 3.

(fixes #220)