### PR TITLE
Nasty hack to support bundle resource files for XCode

### DIFF
--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -408,10 +408,9 @@ class CMakeGen(object):
             resource_files = []
             for f in resource_subdirs:
                 for root, dires, files in os.walk(f):
-                    if ".xcassets/" in root or ".bundle/" in root:
-                        pass
-                    elif root.endswith(".xcassets") or root.endswith(".bundle"):
+                    if root.endswith(".xcassets") or root.endswith(".bundle"):
                         resource_files.append(root)
+                        del dires[:]
                     else:
                         for f in files:
                             resource_files.append(os.path.join(root, f))

--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -408,11 +408,13 @@ class CMakeGen(object):
             resource_files = []
             for f in resource_subdirs:
                 for root, dires, files in os.walk(f):
-                    if root.endswith(".xcassets"):
+                    if ".xcassets/" in root or ".bundle/" in root:
+                        pass
+                    elif root.endswith(".xcassets") or root.endswith(".bundle"):
                         resource_files.append(root)
-                        break;
-                    for f in files:
-                        resource_files.append(os.path.join(root, f))
+                    else:
+                        for f in files:
+                            resource_files.append(os.path.join(root, f))
 
             # Find cmake files
             cmake_files = []


### PR DESCRIPTION
Todo: find a way to do this in the CMake include file which would allow removing these special cases for xcassets and bundle files 