### PR TITLE
add httpURL pattern (the registry rejects an empty string here)

### DIFF
--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -168,7 +168,7 @@
         "httpURL": {
                  "type": "string",
             "maxLength": 1200,
-              "comment": "!!! TODO: pattern"
+              "pattern": "^(https?:\/\/).*$"
         },
         "repositoryURL": {
             "oneOf": [


### PR DESCRIPTION
Note that the property is not required, but if present it must be a valid URL.