### PR TITLE
fix #246

### DIFF
--- a/yotta/install.py
+++ b/yotta/install.py
@@ -55,11 +55,22 @@ def execCommand(args, following_args):
     cwd = os.getcwd()
     c = component.Component(cwd)
     if args.component is None:
-        installDeps(args, c)
+        return installDeps(args, c)
     elif c or c.exists():
-        installComponentAsDependency(args, c)
+        return installComponentAsDependency(args, c)
     else:
-        installComponent(args)
+        return installComponent(args)
+
+def checkPrintStatus(errors, components):
+    status = 0
+    for error in errors:
+        logging.error(error)
+        status = 1
+    for c in components.values():
+        if c and c.getError():
+            logging.error('%s %s', c.getName(), c.getError())
+            status = 1
+    return status
 
 
 def installDeps(args, current_component):
@@ -96,8 +107,7 @@ def installDeps(args, current_component):
             available_components = [(current_component.getName(), current_component)],
                             test = {'own':'toplevel', 'all':True, 'none':False}[args.install_test_deps]
         )
-        for error in errors:
-            logging.error(error)
+        return checkPrintStatus(errors, components)
 
 
 
@@ -161,8 +171,7 @@ def installComponentAsDependency(args, current_component):
                         test = {'own':'toplevel', 'all':True, 'none':False}[args.install_test_deps]
         
     )
-    for error in errors:
-        logging.error(error)
+    return checkPrintStatus(errors, components)
 
 
 def installComponent(args):
@@ -197,4 +206,4 @@ def installComponent(args):
                working_directory = path
         )
     os.chdir(component_name)
-    installDeps(args, component.Component(os.getcwd()))
+    return installDeps(args, component.Component(os.getcwd()))

--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -239,7 +239,7 @@ def satisfyVersionFromSearchPaths(name, version_required, search_paths, update=F
         versions of the found component, and update it in-place (unless it was
         installed via a symlink).
     '''
-    spec = sourceparse.parseSourceURL(version_required).semantic_spec
+    spec = sourceparse.parseSourceURL(version_required).semanticSpec()
     v    = None
     
     try:

--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -201,8 +201,7 @@ def latestSuitableVersion(name, version_required, registry='modules'):
     
     return None
 
-def searchPathsFor(name, version_required, search_paths, type='module'):
-    spec = version.Spec(version_required)
+def searchPathsFor(name, spec, search_paths, type='module'):
     for path in search_paths:
         check_path = os.path.join(path, name)
         logger.debug("check path %s for %s" % (check_path, name))
@@ -240,11 +239,11 @@ def satisfyVersionFromSearchPaths(name, version_required, search_paths, update=F
         versions of the found component, and update it in-place (unless it was
         installed via a symlink).
     '''
-    spec = None
+    spec = sourceparse.parseSourceURL(version_required).semantic_spec
     v    = None
     
     try:
-        local_version = searchPathsFor(name, version_required, search_paths, type)
+        local_version = searchPathsFor(name, spec, search_paths, type)
     except pack.InvalidDescription as e:
         logger.error(e)
         return None
@@ -253,7 +252,7 @@ def satisfyVersionFromSearchPaths(name, version_required, search_paths, update=F
     if local_version:
         if update and not local_version.installedLinked():
             #logger.debug('attempt to check latest version of %s @%s...' % (name, version_required))
-            v = latestSuitableVersion(name, version_required, registry=_registryNamespaceForType(type))
+            v = latestSuitableVersion(name, spec, registry=_registryNamespaceForType(type))
             if local_version:
                 local_version.setLatestAvailable(v)
 

--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -202,6 +202,7 @@ def latestSuitableVersion(name, version_required, registry='modules'):
     return None
 
 def searchPathsFor(name, version_required, search_paths, type='module'):
+    spec = version.Spec(version_required)
     for path in search_paths:
         check_path = os.path.join(path, name)
         logger.debug("check path %s for %s" % (check_path, name))
@@ -210,7 +211,7 @@ def searchPathsFor(name, version_required, search_paths, type='module'):
                    installed_linked = fsutils.isLink(check_path),
             latest_suitable_version = None
         )
-        if instance:
+        if instance and spec.match(instance.getVersion()):
             return instance
     return None
 
@@ -222,23 +223,10 @@ def _clsForType(type):
     assert(type in ('module', 'target'))
     return {'module':component.Component, 'target':target.Target}[type]
 
-def satisfyVersionFromAvailable(name, version_required, available, type='module'):
-    spec = None
+def satisfyFromAvailable(name, available, type='module'):
     if name in available and available[name]:
         logger.debug('satisfy %s from already installed %ss' % (name, type))
-        # we still need to check the version specification - which the remote
-        # components know how to parse:
-        remote_component = remoteComponentFor(name, version_required, _registryNamespaceForType(type))
-        if remote_component.versionSpec():
-            if not remote_component.versionSpec().match(available[name].version):
-                raise access_common.SpecificationNotMet(
-                    "Installed %s %s doesn't match specification %s" % (type, name, remote_component.versionSpec())
-                ) 
         r = available[name]
-        if spec and not spec.match(r.getVersion()):
-            raise access_common.Unavailable(
-                'Previously added %s %s@%s doesn\'t meet spec %s' % (type, name, r.getVersion(), spec)
-            )
         if name != r.getName():
             raise access_common.Unavailable('%s %s was installed as different name %s in %s' % (
                 type, r.getName(), name, r.path
@@ -340,9 +328,13 @@ def satisfyVersion(
             Update: replace any existing version with the newest available, if
                     the newest available has a higher version
     '''
-
-    r = satisfyVersionFromAvailable(name, version_required, available, type=type)
+    
+    r = satisfyFromAvailable(name, available, type=type)
     if r is not None:
+        if not sourceparse.parseSourceURL(version_required).semanticSpecMatches(r.getVersion()):
+            raise access_common.SpecificationNotMet(
+                "Installed %s %s doesn't match specification %s" % (type, name, version_required)
+            ) 
         return r
     
     r = satisfyVersionFromSearchPaths(name, version_required, search_paths, update_installed == 'Update', type=type)

--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -176,6 +176,12 @@ class Pack(object):
         ''' If this isn't a valid component/target, return some sort of
             explanation about why that is. '''
         return self.error
+    
+    def setError(self, error):
+        ''' Set an error: note that setting an error does not make the module
+            invalid if it would otherwise be valid.
+        '''
+        self.error = error
 
     def getDescriptionFile(self):
         return os.path.join(self.path, self.description_filename)

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -341,14 +341,6 @@ class RegistryThingVersion(access_common.RemoteVersion):
         assert(self.url)
         _getTarball(self.url, directory, self.sha256)
 
-    def __eq__(self, other):
-        return self.namespace == other.namespace and \
-               self.name == other.name and \
-               self.version == version
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
 class RegistryThing(access_common.RemoteComponent):
     def __init__(self, name, version_spec, namespace):
         self.name = name

--- a/yotta/lib/sourceparse.py
+++ b/yotta/lib/sourceparse.py
@@ -35,6 +35,10 @@ class VersionSource(object):
                 raise ValueError(
                     "Invalid semantic version spec: \"%s\"" % spec
                 )
+
+    def semanticSpec(self):
+        return self.semantic_spec or version.Spec('*')
+
     def semanticSpecMatches(self, v):
         if self.semantic_spec is None:
             return True

--- a/yotta/lib/sourceparse.py
+++ b/yotta/lib/sourceparse.py
@@ -81,7 +81,7 @@ def parseSourceURL(source_url):
         return VersionSource('github', without_fragment, parsed.fragment)
 
     # something/something@spec = github
-    alternate_github_match = re.match('([a-z0-9_-]+/[a-z0-9_-]+) *@?([~^><=.0-9a-zA-Z\*-]*)', source_url)
+    alternate_github_match = re.match('([a-z0-9_-]+/[a-z0-9_-]+) *@?([~^><=.0-9a-z\*-]*)', source_url, re.I)
     if alternate_github_match:
         return VersionSource('github', alternate_github_match.group(0), alternate_github_match.group(1))
     

--- a/yotta/lib/sourceparse.py
+++ b/yotta/lib/sourceparse.py
@@ -35,6 +35,12 @@ class VersionSource(object):
                 raise ValueError(
                     "Invalid semantic version spec: \"%s\"" % spec
                 )
+    def semanticSpecMatches(self, v):
+        if self.semantic_spec is None:
+            return True
+        else:
+            return self.semantic_spec.match(v)
+
 
 def parseSourceURL(source_url):
     ''' Parse the specified version source URL (or version spec), and return an


### PR DESCRIPTION
Fixes #246 

Propagate non-zero exit status on all build/install errors, such as those caused by mismatched version specs (even though the build may succeed).

In the process I've made some architectural improvements to the dependency-finding code (de-duplicating the code which searches search-paths for example).
