### PR TITLE
add missing quotes preventing build with spaces in path; add tests for building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - sudo apt-get remove -y cmake
   - curl -fsSL http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-i386.sh > /tmp/install-cmake.sh
   - chmod +x /tmp/install-cmake.sh
-  - sudo /tmp/install-cmake.sh --prefix=/usr/local --exclude-subdir
+  - sudo /tmp/install-cmake.sh --prefix=/usr --exclude-subdir
   - pip install .
 before_script:
   - /bin/bash .travis_init.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ python:
   #- "pypy"
 # command to install dependencies
 install:
+  # install a newer version of CMake:
+  - echo "yes" | sudo add-apt-repository ppa:kalakris/cmake
+  - sudo apt-get update -qq
+  - sudo apt-get install cmake
   - pip install .
 before_script:
   - /bin/bash .travis_init.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ python:
 install:
   # install a newer version of CMake:
   - sudo apt-get remove -y cmake
-  - curl -fsSL http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-i386.sh > /tmp/install-cmake.sh
+  - curl -fsSL http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.sh > /tmp/install-cmake.sh
   - chmod +x /tmp/install-cmake.sh
-  - sudo /tmp/install-cmake.sh --prefix=/usr --exclude-subdir
+  - sudo /tmp/install-cmake.sh --prefix=/usr/local --exclude-subdir
   - pip install .
 before_script:
   - /bin/bash .travis_init.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ python:
 # command to install dependencies
 install:
   # install a newer version of CMake:
-  - echo "yes" | sudo add-apt-repository ppa:kalakris/cmake
-  - sudo apt-get update -qq
-  - sudo apt-get install cmake
+  - sudo apt-get remove -y cmake
+  - curl -fsSL http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-i386.sh > /tmp/install-cmake.sh
+  - chmod +x /tmp/install-cmake.sh
+  - sudo /tmp/install-cmake.sh --prefix=/usr/local --exclude-subdir
   - pip install .
 before_script:
   - /bin/bash .travis_init.sh

--- a/yotta/lib/detect.py
+++ b/yotta/lib/detect.py
@@ -10,11 +10,14 @@ import sys
 # settings, , load and save settings, internal
 import settings
 
-def defaultTarget():
+def defaultTarget(ignore_set_target=False):
     set_target = settings.getProperty('build', 'target')
     if set_target:
         return set_target
+    else:
+        return systemDefaultTarget()
 
+def systemDefaultTarget():
     machine = platform.machine()
 
     x86 = machine.find('86') != -1

--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -27,9 +27,9 @@ project({{ component_name }})
 {% if toplevel %}
 # Definitions provided by the target configuration info:
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "ARMCC")
-    add_definitions("--preinclude {{ config_include_file | replaceBackslashes }}")
+    add_definitions("--preinclude \"{{ config_include_file | replaceBackslashes }}\"")
 else()
-    add_definitions("-include {{ config_include_file | replaceBackslashes }}")
+    add_definitions("-include \"{{ config_include_file | replaceBackslashes }}\"")
 endif()
 {% endif %}
 

--- a/yotta/lib/templates/subdir_CMakeLists.txt
+++ b/yotta/lib/templates/subdir_CMakeLists.txt
@@ -20,7 +20,9 @@ set(YOTTA_AUTO_{{ object_name.upper() }}_{{ lang | upper }}_FILES
 
 {% if resource_files %}
 set(YOTTA_AUTO_{{ object_name.upper() }}_RESOURCE_FILES
-    {{ resource_files | join('\n    ') }}
+  {% for file_name in resource_files %}
+    "{{ file_name | replaceBackslashes }}"
+  {% endfor %}
 )
 {% endif %}
 

--- a/yotta/lib/templates/test_CMakeLists.txt
+++ b/yotta/lib/templates/test_CMakeLists.txt
@@ -25,7 +25,9 @@ include_directories("{{ source_directory | replaceBackslashes }}")
 
 {% for file_names, object_name, languages in tests %}
 add_executable({{ object_name }} {{ 'EXCLUDE_FROM_ALL' if exclude_from_all else '' }}
-    {{ file_names | join('\n    ') | replaceBackslashes }}
+    {% for filename in file_names %}
+        "{{ filename | replaceBackslashes }}"
+    {% endfor %}
 )
 {% if 'objc' in languages %}
 # no proper CMake support for objective-c flags :(

--- a/yotta/test/cli/build.py
+++ b/yotta/test/cli/build.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# Copyright 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library modules, , ,
+import unittest
+import os
+import sys
+import tempfile
+
+# internal modules:
+from yotta.lib.fsutils import mkDirP, rmRf
+from yotta.lib.detect import systemDefaultTarget
+from . import cli
+
+Test_Complex = {
+'module.json': '''{
+  "name": "test-testdep-a",
+  "version": "0.0.2",
+  "description": "Module to test test-dependencies",
+  "licenses": [
+    {
+      "url": "https://spdx.org/licenses/Apache-2.0",
+      "type": "Apache-2.0"
+    }
+  ],
+  "dependencies": {
+    "test-testdep-b": "*",
+    "test-testdep-c": "*",
+    "test-testdep-d": "*"
+  },
+  "testDependencies": {
+    "test-testdep-e": "*"
+  }
+}
+''',
+
+'source/a.c': '''
+#include "a/a.h"
+#include "b/b.h"
+#include "c/c.h"
+#include "d/d.h"
+
+int a(){
+    return 1 + b() + c() + d(); // 35
+}
+''',
+
+'source/a.c': '''
+#include "a/a.h"
+#include "b/b.h"
+#include "c/c.h"
+#include "d/d.h"
+
+int a(){
+    return 1 + b() + c() + d(); // 35
+}
+''',
+
+'a/a.h':'''
+#ifndef __A_H__
+#define __A_H__
+int a();
+#endif
+''',
+
+'test/check.c': '''
+#include <stdio.h>
+
+#include "a/a.h"
+#include "b/b.h"
+#include "c/c.h"
+#include "d/d.h"
+#include "e/e.h"
+
+
+int main(){
+    int result = a() + b() + c() + d() + e();
+    printf("%d\\n", result);
+    return !(result == 86);
+}
+'''
+}
+
+
+Test_Trivial_Lib = {
+'module.json':'''{
+  "name": "test-trivial-lib",
+  "version": "0.0.2",
+  "description": "Module to test trivial lib compilation",
+  "licenses": [
+    {
+      "url": "https://spdx.org/licenses/Apache-2.0",
+      "type": "Apache-2.0"
+    }
+  ],
+  "dependencies": {
+  }
+}''',
+
+'test-trivial-lib/lib.h': '''
+int foo();
+''',
+
+'source/lib.c':'''
+#include "test-trivial-lib/lib.h"
+
+int foo(){
+    return 7;
+}
+'''
+}
+
+Test_Trivial_Exe = {
+'module.json':'''{
+  "name": "test-trivial-exe",
+  "version": "0.0.2",
+  "description": "Module to test trivial exe compilation",
+  "licenses": [
+    {
+      "url": "https://spdx.org/licenses/Apache-2.0",
+      "type": "Apache-2.0"
+    }
+  ],
+  "dependencies": {
+  }
+}''',
+
+'source/lib.c':'''
+int main(){
+    return 0;
+}
+'''
+}
+
+def isWindows():
+    # can't run tests that hit github without an authn token
+    return sys.platform == 'nt'
+
+
+class TestCLIInstall(unittest.TestCase):
+    def writeTestFiles(self, files, add_space_in_path=False):
+        test_dir = tempfile.mkdtemp()
+        if add_space_in_path:
+            test_dir = test_dir + ' spaces in path'
+
+        for path, contents in files.items():
+            path_dir, file_name =  os.path.split(path)
+            path_dir = os.path.join(test_dir, path_dir)
+            mkDirP(path_dir)
+            with open(os.path.join(path_dir, file_name), 'w') as f:
+                f.write(contents)
+        return test_dir
+
+
+    @unittest.skipIf(isWindows(), "can't build natively on windows yet")
+    def test_buildTrivialLib(self):
+        test_dir = self.writeTestFiles(Test_Trivial_Lib)
+
+        stdout = self.runCheckCommand(['--target', systemDefaultTarget(), 'build'], test_dir)
+
+        rmRf(test_dir)
+
+    @unittest.skipIf(isWindows(), "can't build natively on windows yet")
+    def test_buildTrivialExe(self):
+        test_dir = self.writeTestFiles(Test_Trivial_Exe)
+
+        stdout = self.runCheckCommand(['--target', systemDefaultTarget(), 'build'], test_dir)
+
+        rmRf(test_dir)
+
+    @unittest.skipIf(isWindows(), "can't build natively on windows yet")
+    def test_buildZComplex(self):
+        test_dir = self.writeTestFiles(Test_Complex)
+
+        stdout = self.runCheckCommand(['--target', systemDefaultTarget(), 'build'], test_dir)
+
+        rmRf(test_dir)
+
+    @unittest.skipIf(isWindows(), "can't build natively on windows yet")
+    def test_buildZZComplexSpaceInPath(self):
+        test_dir = self.writeTestFiles(Test_Complex, True)
+
+        stdout = self.runCheckCommand(['--target', systemDefaultTarget(), 'build'], test_dir)
+
+        rmRf(test_dir)
+
+
+    def runCheckCommand(self, args, test_dir):
+        stdout, stderr, statuscode = cli.run(args, cwd=test_dir)
+        #print stdout, stderr
+        self.assertEqual(statuscode, 0)
+        return stdout or stderr

--- a/yotta/test/cli/build.py
+++ b/yotta/test/cli/build.py
@@ -190,6 +190,9 @@ class TestCLIBuild(unittest.TestCase):
 
     def runCheckCommand(self, args, test_dir):
         stdout, stderr, statuscode = cli.run(args, cwd=test_dir)
-        print stdout, stderr
+        if statuscode != 0:
+            print('command failed with status %s' % statuscode)
+            print(stdout)
+            print(stderr)
         self.assertEqual(statuscode, 0)
         return stdout or stderr

--- a/yotta/test/cli/build.py
+++ b/yotta/test/cli/build.py
@@ -140,7 +140,7 @@ def isWindows():
     return sys.platform == 'nt'
 
 
-class TestCLIInstall(unittest.TestCase):
+class TestCLIBuild(unittest.TestCase):
     def writeTestFiles(self, files, add_space_in_path=False):
         test_dir = tempfile.mkdtemp()
         if add_space_in_path:
@@ -190,6 +190,6 @@ class TestCLIInstall(unittest.TestCase):
 
     def runCheckCommand(self, args, test_dir):
         stdout, stderr, statuscode = cli.run(args, cwd=test_dir)
-        #print stdout, stderr
+        print stdout, stderr
         self.assertEqual(statuscode, 0)
         return stdout or stderr

--- a/yotta/test/cli/search.py
+++ b/yotta/test/cli/search.py
@@ -46,7 +46,7 @@ class TestCLISearch(unittest.TestCase):
         if statuscode != 0:
             print('command failed with status %s' % statuscode)
             print(stdout)
-            print(strerr)
+            print(stderr)
         self.assertEqual(statuscode, 0)
         return stdout or stderr
 


### PR DESCRIPTION
This fixes #133.

Note that the building tests are skipped on windows (they build using the native compiler, and there is no default native target for windows yet).