### PR TITLE
Fix 'yotta version' in Windows

### DIFF
--- a/yotta/lib/vcs.py
+++ b/yotta/lib/vcs.py
@@ -110,7 +110,7 @@ class Git(VCS):
         return self.worktree
 
     def _gitCmd(self, *args):
-        return ['git','--work-tree=%s' % self.worktree,'--git-dir=%s'%self.gitdir] + list(args);
+        return ['git','--work-tree=%s' % self.worktree,'--git-dir=%s'%self.gitdir.replace('\\', '/')] + list(args);
     
     @classmethod
     def _execCommands(cls, commands):


### PR DESCRIPTION
Without this patch, 'yotta version' would fail with an 'Invalid argument'
error in Windows. With this patch, the command works. No idea why it works,
but it does. Also, it seems that replacing '\' with '/' only needs to
happen for --git-dir, --work-tree doesn't have a problem with backslashes.