### PR TITLE
improve and document .yotta_ignore support

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -45,6 +45,7 @@
             <li data-section="reference/commands"><a href="{{ site.github.url }}/reference/commands.html">Command Reference</a></li>
             <li data-section="reference/module"><a href="{{ site.github.url }}/reference/module.html">module.json</a></li>
             <li data-section="reference/target"><a href="{{ site.github.url }}/reference/target.html">target.json</a></li>
+            <li data-section="reference/ignore"><a href="{{ site.github.url }}/reference/ignore.html">.yotta_ignore</a></li>
           </ul>
         </div>
         <div class="col-sm-9">

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -302,7 +302,10 @@ yotta publish
 ```
 
 #### Description
-Publish the current module or target to the public `yotta` registry, where other people will be able to search for and install it.
+Publish the current module or target to the public [`yotta` registry](https://yottabuild.org), where other people will be able to search for and install it.
+
+Any files matching lines in the `.yotta_ignore` file (if present) are ignored,
+and will not be included in the published tarball.
 
 
 <a name="yotta-link"></a>

--- a/docs/reference/ignore.md
+++ b/docs/reference/ignore.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: target.json
+section: reference/ignore
+---
+
+# .yotta_ignore Reference
+
+A `.yotta_ingore` file can be added to any module or target to make yotta
+completely ignore any listed files. Listed files are ignored when
+auto-generating build files, and when publishing to the registry (but note that
+custom CMakeLists files may still refer to ignored files).
+
+
+## Syntax
+
+Glob-style syntax is supported, with one pattern per line in the ignore file.
+Lines in the ignore file starting with `#` are comments and will not be parsed
+by yotta.
+
+Any file or directory that matches any pattern in the ignore file will be ignored.
+
+Any files within an ignored directory will also be ignored.
+
+`*` matches zero or more of any character, but does not match a directory separator
+`*` matches any character exactly once, but does not match a directory separator
+`[]` matches any character within [] exactly once
+
+If a pattern starts with a / then it is an **absolute** pattern, and the whole
+path relative to the root of the module must match.
+
+If a pattern does not start with a / then it is a **relative** pattern, and
+will match files and directories with any parent hierarchy.
+
+Note that with the relative pattern `b/c`, and a directory hierarchy `a/b/c/d/e`,
+the whole of the directory `c` (including any subdirectory `d`) will be ignored. 
+
+### Examples
+
+ * Ignore all files in `test/bar/`: `/test/bar/*`
+ * Ignore all .tar.gz and .tar.gz files in the root directory: `/*.tar.[bg]z`
+ * Ignore all .swp files everywhere: `*.swp`
+ * Ignore all dotfiles files everywhere: `.*`
+
+
+## Always-Ingored Files
+
+Files matching some patterns will always be ignored by yotta, whether or not a
+.yotta_ignore file is present. This list currently includes:
+
+`/upload.tar.gz`
+`/upload.tar.bz`
+`/.git`
+`/.hg`
+`/.svn`
+`/yotta_modules`
+`/yotta_targets`
+`/build`
+`.DS_Store`
+`.sw[ponml]`
+`*~`
+`._.*`
+`.yotta.json`

--- a/docs/reference/target.md
+++ b/docs/reference/target.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: target.json
-section: yotta/target
+section: reference/target
 ---
 
 # target.json Reference

--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -34,13 +34,13 @@ import registry_access
 # These patterns are used in addition to any glob expressions defined by the
 # .yotta_ignore file
 Default_Publish_Ignore = [
-    'upload.tar.[gb]z',
-    '.git',
-    '.hg',
-    '.svn',
-    'yotta_modules',
-    'yotta_targets',
-    'build',
+    '/upload.tar.[gb]z',
+    '/.git',
+    '/.hg',
+    '/.svn',
+    '/yotta_modules',
+    '/yotta_targets',
+    '/build',
     '.DS_Store',
     '.sw[ponml]',
     '*~',
@@ -246,13 +246,23 @@ class Pack(object):
         return r
 
     def ignores(self, path):
-        ''' Test if this module ignores the file at "path" '''
-        test_path = PurePath(path)
+        ''' Test if this module ignores the file at "path", which must be a
+            path relative to the root of the module.
+
+            If a file is within a directory that is ignored, the file is also
+            ignored.
+        '''
+        test_path = PurePath('/', path)
+        
+        # also check any parent directories of this path against the ignore
+        # patterns:
+        test_paths = tuple([test_path] + list(test_path.parents))
 
         for exp in self.ignore_patterns:
-            if test_path.match(exp):
-                logger.debug('"%s" ignored' % path)
-                return True
+            for tp in test_paths:
+                if tp.match(exp):
+                    logger.debug('"%s" ignored ("%s" matched "%s")', path, tp, exp)
+                    return True
         return False
 
     def setVersion(self, version):

--- a/yotta/test/ignores.py
+++ b/yotta/test/ignores.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+# Copyright 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+
+# standard library modules, , ,
+import unittest
+import os
+import subprocess
+from collections import namedtuple
+import tempfile
+
+# internal modules:
+from yotta.lib import sourceparse
+from yotta.lib.fsutils import mkDirP, rmRf
+from yotta.lib.detect import systemDefaultTarget
+from yotta.lib import component 
+from cli import cli
+
+Test_Files = {
+    '.yotta_ignore': '''
+#comment
+/moo
+b/c/d
+b/c/*.txt
+/a/b/test.txt
+b/*.c
+/source/a/b/test.txt
+/test/foo
+sometest/a
+someothertest
+ignoredbyfname.c
+''',
+    'module.json': '''
+{
+  "name": "test-testdep-f",
+  "version": "0.0.6",
+  "description": "Module to test test-dependencies and ignoring things",
+  "author": "autopulated",
+  "licenses": [
+    {
+      "url": "https://spdx.org/licenses/Apache-2.0",
+      "type": "Apache-2.0"
+    }
+  ],
+  "dependencies": {},
+  "testDependencies": {}
+}
+''',
+
+'a/b/c/d/e/f/test.txt': '',
+'a/b/c/d/e/test.c': '#error should be ignored',
+'a/b/c/d/e/test.txt': '',
+'a/b/c/d/test.c': '#error should be ignored',
+'a/b/c/d/test.txt': '',
+'a/b/c/d/z/test.c':'#error should be ignored',
+'a/b/c/test.txt': '',
+'a/b/test.txt':'',
+'a/test.txt':'',
+'comment':'# should not be ignored',
+'f/f.h':'''
+#ifndef __F_H__
+#define __F_H__
+int f();
+#endif
+''',
+'source/moo/test.txt':'',
+'source/a/b/c/d/e/f/test.txt': '',
+'source/a/b/c/d/e/test.c': '#error should be ignored',
+'source/a/b/c/d/e/test.txt': '',
+'source/a/b/c/d/test.c': '#error should be ignored',
+'source/a/b/c/d/test.txt': '',
+'source/a/b/c/d/z/test.c':'#error should be ignored',
+'source/a/b/c/test.txt': '',
+'source/a/b/test.txt':'',
+'source/a/test.txt':'',
+'source/f.c':'''
+
+int f(){
+    return 6;
+}
+''',
+'test/anothertest/ignoredbyfname.c':'#error should be ignored',
+'test/anothertest/ignoredbyfname.c':'''
+#include <stdio.h>
+
+#include "f/f.h"
+
+int main(){
+    int result = f();
+    printf("%d\n", result);
+    return !(result == 6);
+}
+''',
+'test/foo/ignored.c':'''
+#error should be ignored
+''',
+'test/someothertest/alsoignored.c':'''
+#error should be ignored
+''',
+'test/sometest/a/ignored.c':'''
+#error should be ignored
+'''
+}
+
+def isWindows():
+    # can't run tests that hit github without an authn token
+    return os.name == 'nt'
+
+class TestPackIgnores(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+        for path, contents in Test_Files.items():
+            path_dir, file_name =  os.path.split(path)
+            path_dir = os.path.join(self.test_dir, path_dir)
+            mkDirP(path_dir)
+            with open(os.path.join(path_dir, file_name), 'w') as f:
+                f.write(contents)
+        
+    def tearDown(self):
+        rmRf(self.test_dir)
+
+    def test_absolute_ignores(self):
+        c = component.Component(self.test_dir)
+        self.assertTrue(c.ignores('moo'))
+        self.assertTrue(c.ignores('test/foo/ignored.c'))
+
+    def test_glob_ignores(self):
+        c = component.Component(self.test_dir)
+        self.assertTrue(c.ignores('a/b/c/test.txt'))
+        self.assertTrue(c.ignores('a/b/test.txt'))
+        self.assertTrue(c.ignores('a/b/test.c'))
+        self.assertTrue(c.ignores('source/a/b/c/test.txt'))
+        self.assertTrue(c.ignores('source/a/b/test.txt'))
+        self.assertTrue(c.ignores('source/a/b/test.c'))
+
+    def test_relative_ignores(self):
+        c = component.Component(self.test_dir)
+        self.assertTrue(c.ignores('a/b/c/d/e/f/test.txt'))
+        self.assertTrue(c.ignores('a/b/test.txt'))
+        self.assertTrue(c.ignores('source/a/b/c/d/e/f/test.txt'))
+        self.assertTrue(c.ignores('source/a/b/test.txt'))
+        self.assertTrue(c.ignores('test/anothertest/ignoredbyfname.c'))
+        self.assertTrue(c.ignores('test/someothertest/alsoignored.c'))
+
+    def test_comments(self):
+        c = component.Component(self.test_dir)
+        self.assertFalse(c.ignores('comment'))
+
+    @unittest.skipIf(isWindows(), "can't build natively on windows yet")
+    def test_build(self):
+        stdout = self.runCheckCommand(['--target', systemDefaultTarget(), 'clean'], self.test_dir)
+        stdout = self.runCheckCommand(['--target', systemDefaultTarget(), 'build'], self.test_dir)
+        self.assertNotIn('ignoredbyfname', stdout)
+        self.assertNotIn('someothertest', stdout)
+        self.assertNotIn('sometest', stdout)
+
+    @unittest.skipIf(isWindows(), "can't build natively on windows yet")
+    def test_test(self):
+        stdout = self.runCheckCommand(['--target', systemDefaultTarget(), 'clean'], self.test_dir)
+        stdout = self.runCheckCommand(['--target', systemDefaultTarget(), 'test'], self.test_dir)
+        self.assertNotIn('ignoredbyfname', stdout)
+        self.assertNotIn('someothertest', stdout)
+        self.assertNotIn('sometest', stdout)
+    
+    def runCheckCommand(self, args, test_dir):
+        stdout, stderr, statuscode = cli.run(args, cwd=self.test_dir)
+        if statuscode != 0:
+            print('command failed with status %s' % statuscode)
+            print(stdout)
+            print(stderr)
+        self.assertEqual(statuscode, 0)
+        return stdout or stderr
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+


### PR DESCRIPTION
 * add .yotta_ingore section to docs/reference
 * ignore files if their parent directory is ignored
 * support both absolute and relative ignore paths
 * fixes #258 and #241, largely mitigates #81

(planning to add a set of tests for ignore patterns before merging this)