### PR TITLE
Fix various 'link' issues in Windows

### DIFF
--- a/yotta/lib/fsutils_posix.py
+++ b/yotta/lib/fsutils_posix.py
@@ -76,3 +76,6 @@ def _symlink(source, link_name):
 
 def realpath(path):
     return os.path.realpath(path)
+
+def rmLink(path):
+    os.unlink(path)

--- a/yotta/lib/fsutils_win.py
+++ b/yotta/lib/fsutils_win.py
@@ -37,3 +37,8 @@ def _symlink(source, link_name):
 
 def realpath(path):
     return os.path.abspath(tryReadLink(path) or path)
+
+def rmLink(path):
+    # Apparently, it's possible to delete both directory links and file links
+    # with 'rmdir' in Windows
+    os.rmdir(path)


### PR DESCRIPTION
1. linking the same module twice in Windows will lead to deleting its directory,
   because of the way 'rmtree' works in Windows (doesn't throw an error when
   finding a link)
2. 'yt unlink' now works properly

Tested on Windows only.