### PR TITLE
Build system improvements

### DIFF
--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -19,6 +19,26 @@ cmake_policy(SET CMP0017 OLD)
 # toolchain file for {{ target_name }}
 set(CMAKE_TOOLCHAIN_FILE "{{ toolchain_file | replaceBackslashes }}")
 
+# provide function for post-processing executables
+function (yotta_postprocess_target target_type_ target_name_)
+    if(COMMAND yotta_apply_target_rules)
+        yotta_apply_target_rules(${target_type_} ${target_name_})
+    endif()
+
+    # For backwards compatibility, support YOTTA_POSTPROCESS_COMMAND.
+    if(DEFINED YOTTA_POSTPROCESS_COMMAND)
+        message(AUTHOR_WARNING "This target defines a YOTTA_POSTPROCESS_COMMAND for which support has been deprecated. Please define a CMake function yotta_apply_target_rules(build_object_type build_object) instead.")
+        string(REPLACE YOTTA_CURRENT_EXE_NAME "serial-helloworld" LOCAL_POSTPROCESS_COMMAND "${YOTTA_POSTPROCESS_COMMAND}")
+        separate_arguments(LOCAL_POSTPROCESS_COMMAND_SEPARATED UNIX_COMMAND ${LOCAL_POSTPROCESS_COMMAND})
+        add_custom_command(
+            TARGET serial-helloworld
+            POST_BUILD
+            COMMAND ${LOCAL_POSTPROCESS_COMMAND_SEPARATED}
+        )
+    endif()
+endfunction()
+
+# set target-defined definitions
 {{ set_definitions }}
 {% endif %}
 

--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -46,11 +46,7 @@ project({{ component_name }})
 
 {% if toplevel %}
 # Definitions provided by the target configuration info:
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "ARMCC")
-    add_definitions("--preinclude \"{{ config_include_file | replaceBackslashes }}\"")
-else()
-    add_definitions("-include \"{{ config_include_file | replaceBackslashes }}\"")
-endif()
+add_definitions("${YOTTA_FORCE_INCLUDE_FLAG} \"{{ config_include_file | replaceBackslashes }}\"")
 {% endif %}
 
 # include root directories of all components we depend on (directly and

--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -26,12 +26,12 @@ function (yotta_postprocess_target target_type_ target_name_)
     endif()
 
     # For backwards compatibility, support YOTTA_POSTPROCESS_COMMAND.
-    if(DEFINED YOTTA_POSTPROCESS_COMMAND)
-        message(AUTHOR_WARNING "This target defines a YOTTA_POSTPROCESS_COMMAND for which support has been deprecated. Please define a CMake function yotta_apply_target_rules(build_object_type build_object) instead.")
-        string(REPLACE YOTTA_CURRENT_EXE_NAME "serial-helloworld" LOCAL_POSTPROCESS_COMMAND "${YOTTA_POSTPROCESS_COMMAND}")
+    if(DEFINED YOTTA_POSTPROCESS_COMMAND AND ${target_type_} STREQUAL "EXECUTABLE")
+        #message(AUTHOR_WARNING "This target defines a YOTTA_POSTPROCESS_COMMAND for which support has been deprecated. Please define a CMake function yotta_apply_target_rules(build_object_type build_object) instead.")
+        string(REPLACE YOTTA_CURRENT_EXE_NAME "${target_name_}" LOCAL_POSTPROCESS_COMMAND "${YOTTA_POSTPROCESS_COMMAND}")
         separate_arguments(LOCAL_POSTPROCESS_COMMAND_SEPARATED UNIX_COMMAND ${LOCAL_POSTPROCESS_COMMAND})
         add_custom_command(
-            TARGET serial-helloworld
+            TARGET ${target_name_}
             POST_BUILD
             COMMAND ${LOCAL_POSTPROCESS_COMMAND_SEPARATED}
         )
@@ -46,6 +46,9 @@ project({{ component_name }})
 
 {% if toplevel %}
 # Definitions provided by the target configuration info:
+if(NOT DEFINED YOTTA_FORCE_INCLUDE_FLAG)
+    set(YOTTA_FORCE_INCLUDE_FLAG "-include")
+endif()
 add_definitions("${YOTTA_FORCE_INCLUDE_FLAG} \"{{ config_include_file | replaceBackslashes }}\"")
 {% endif %}
 

--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -54,6 +54,12 @@ endif()
 {{ include_other_dirs }}
 {% endif %}
 
+# modules with custom CMake build systems may append to the
+# YOTTA_GLOBAL_INCLUDE_DIRS property to add compile-time-determined include
+# directories:
+get_property(GLOBAL_INCLUDE_DIRS GLOBAL PROPERTY YOTTA_GLOBAL_INCLUDE_DIRS)
+include_directories(${GLOBAL_INCLUDE_DIRS})
+
 # Provide the version of the component being built, in case components want to
 # embed this into compiled libraries
 set(YOTTA_COMPONENT_VERSION "{{ component_version }}")

--- a/yotta/lib/templates/subdir_CMakeLists.txt
+++ b/yotta/lib/templates/subdir_CMakeLists.txt
@@ -48,16 +48,9 @@ add_library({{ object_name }}
 {% endif %}
 
 {% if executable %}
-# if the target has defined a post-processing step, perform it:
-if(YOTTA_POSTPROCESS_COMMAND)
-    string(REPLACE YOTTA_CURRENT_EXE_NAME "{{ object_name }}" LOCAL_POSTPROCESS_COMMAND "${YOTTA_POSTPROCESS_COMMAND}")
-    separate_arguments(LOCAL_POSTPROCESS_COMMAND_SEPARATED UNIX_COMMAND ${LOCAL_POSTPROCESS_COMMAND})
-    add_custom_command(
-        TARGET {{ object_name }}
-        POST_BUILD
-        COMMAND ${LOCAL_POSTPROCESS_COMMAND_SEPARATED}
-    )
-endif()
+yotta_postprocess_target(EXECUTABLE {{ object_name }})
+{% else %}
+yotta_postprocess_target(LIBRARY {{ object_name }})
 {% endif %}
 
 {% if resource_files %}

--- a/yotta/lib/templates/test_CMakeLists.txt
+++ b/yotta/lib/templates/test_CMakeLists.txt
@@ -38,16 +38,7 @@ set_target_properties({{ object_name }} PROPERTIES
 target_link_libraries({{ object_name }}
     {{ link_dependencies | join('\n    ') }}
 )
-# if the target has defined a post-processing step, perform it:
-if(YOTTA_POSTPROCESS_COMMAND)
-    string(REPLACE YOTTA_CURRENT_EXE_NAME "{{ object_name }}" LOCAL_POSTPROCESS_COMMAND "${YOTTA_POSTPROCESS_COMMAND}")
-    separate_arguments(LOCAL_POSTPROCESS_COMMAND_SEPARATED UNIX_COMMAND ${LOCAL_POSTPROCESS_COMMAND})
-    add_custom_command(
-        TARGET {{ object_name }}
-        POST_BUILD
-        COMMAND ${LOCAL_POSTPROCESS_COMMAND_SEPARATED}
-    )
-endif()
+yotta_postprocess_target(EXECUTABLE {{ object_name }})
 add_test({{ object_name }} {{ object_name }})
 add_dependencies(all_tests {{ object_name }})
 


### PR DESCRIPTION
 * Allow modules with custom CMake build systems to export global include dirs.
 * significantly reduce the size of generated CMakeLists by using functions defined up-front instead of repeating templates
 * define more flexible way for targets to add commands or do other things to build objects
 * require targets to define YOTTA_FORCE_INCLUDE_FLAG