### PR TITLE
provide version definitions, fixes #273

### DIFF
--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -42,7 +42,7 @@ endfunction()
 {{ set_definitions }}
 {% endif %}
 
-project({{ component_name }})
+project({{ component.getName() }})
 
 {% if toplevel %}
 # Definitions provided by the target configuration info:
@@ -81,8 +81,19 @@ include_directories(${GLOBAL_INCLUDE_DIRS})
 
 # Provide the version of the component being built, in case components want to
 # embed this into compiled libraries
-set(YOTTA_COMPONENT_VERSION "{{ component_version }}")
-add_definitions(-DYOTTA_COMPONENT_VERSION="{{ component_version }}")
+# !!! WARNING: use of this is deprecated, please use the
+# YOTTA_<MODNAME>_VERSION_STRING / _MAJOR / _MINOR / _PATCH definitions instead
+set(YOTTA_COMPONENT_VERSION "{{ component.getVersion() }}")
+add_definitions(-DYOTTA_COMPONENT_VERSION="{{ component.getVersion() }}")
+
+# Provide versions of all the components we depend on, the corresponding
+# preprocessor definitions are generated in yotta_config.h
+{% for dep in active_dependencies.values() + [component] %}
+set(YOTTA_{{ dep.getName() | sanitizePreprocessorSymbol }}_VERSION_STRING "{{ dep.getVersion() }}")
+set(YOTTA_{{ dep.getName() | sanitizePreprocessorSymbol }}_VERSION_MAJOR {{ dep.getVersion().major() }})
+set(YOTTA_{{ dep.getName() | sanitizePreprocessorSymbol }}_VERSION_MINOR {{ dep.getVersion().minor() }})
+set(YOTTA_{{ dep.getName() | sanitizePreprocessorSymbol }}_VERSION_PATCH {{ dep.getVersion().patch() }})
+{% endfor %}
 
 {% if delegate_to %}
 # delegate to an existing CMakeLists.txt:


### PR DESCRIPTION
Both CMake set-definitions, and preprocessor definitions are defined:

So git commit messages stripped out my nice example code...
```C
#define YOTTA_<MODULENAME>_VERSION_STRING "1.2.3-whatever+stuffmightbehere"
#define YOTTA_<MODULENAME>_VERSION_MAJOR 1
#define YOTTA_<MODULENAME>_VERSION_MINOR 2
#define YOTTA_<MODULENAME>_VERSION_PATCH 3
```

```CMake
set(YOTTA_<MODULENAME>_VERSION_STRING "1.2.3-whatever+etc")
set(YOTTA_<MODULENAME>_VERSION_MAJOR 1)
set(YOTTA_<MODULENAME>_VERSION_MINOR 1)
set(YOTTA_<MODULENAME>_VERSION_PATCH 3)
```