### PR TITLE
yotta test bugfixes

### DIFF
--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -427,7 +427,7 @@ class CMakeGen(object):
             if f.lang in ('c', 'cpp', 'objc', 's'):
                 subrelpath = os.path.relpath(f.relpath, dirname)
                 subdir = fsutils.fullySplitPath(subrelpath)[0]
-                if subdir:
+                if subdir and subdir != subrelpath:
                     subdirs[subdir].append(f)
                 else:
                     toplevel_srcs.append(f)

--- a/yotta/test_subcommand.py
+++ b/yotta/test_subcommand.py
@@ -118,7 +118,8 @@ def execCommand(args, following_args):
 
     all_modules = c.getDependenciesRecursive(
                       target = target,
-        available_components = [(c.getName(), c)]
+        available_components = [(c.getName(), c)],
+                        test = True
     )
 
 


### PR DESCRIPTION
Fix #280, and issue where single-source-file test names would include the file extension of the test source file.