### PR TITLE
toolchain is an optional property in target descriptions

### DIFF
--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -222,7 +222,7 @@ class DerivedTarget(Target):
 
     def getToolchainFiles(self):
         return [
-            os.path.join(x.path, x.description['toolchain']) for x in self.hierarchy
+            os.path.join(x.path, x.description['toolchain']) for x in self.hierarchy if 'toolchain' in x.description
         ]
     
     @classmethod


### PR DESCRIPTION
a target may not add anything at all to the doolcahin configuration, but just provide configuration data,  make sure this is supported (fixes #284)