### PR TITLE
Fix some cases where linked components wouldn't be indicated by `yt ls`

### DIFF
--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -210,6 +210,7 @@ def searchPathsFor(name, spec, search_paths, type='module'):
                    installed_linked = fsutils.isLink(check_path),
             latest_suitable_version = None
         )
+        logger.debug("got %s v=%s spec %s matches? %s", instance, instance.getVersion(), spec, spec.match(instance.getVersion()))
         if instance and spec.match(instance.getVersion()):
             return instance
     return None

--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -210,9 +210,12 @@ def searchPathsFor(name, spec, search_paths, type='module'):
                    installed_linked = fsutils.isLink(check_path),
             latest_suitable_version = None
         )
-        logger.debug("got %s v=%s spec %s matches? %s", instance, instance.getVersion(), spec, spec.match(instance.getVersion()))
-        if instance and spec.match(instance.getVersion()):
-            return instance
+        if instance:
+            logger.debug("got %s v=%s spec %s matches? %s", instance, instance.getVersion(), spec, spec.match(instance.getVersion()))
+            if spec.match(instance.getVersion()):
+                return instance
+        else:
+            logger.debug("got %s", instance)
     return None
 
 def _registryNamespaceForType(type):

--- a/yotta/lib/component.py
+++ b/yotta/lib/component.py
@@ -361,8 +361,14 @@ class Component(pack.Pack):
         # as well as just available ones
         # note that this Component object may still be valid (usable to
         # attempt a build), if a different version was previously installed
-        # on disk at this location
-        r = Component(os.path.join(self.modulesPath(), dspec.name), test_dependency = dspec.is_test_dependency)
+        # on disk at this location (which means we need to check if the
+        # existing version is linked)
+        default_path = os.path.join(self.modulesPath(), dspec.name)
+        r = Component(
+                               default_path,
+             test_dependency = dspec.is_test_dependency,
+            installed_linked = fsutils.isLink(default_path)
+        )
         return r
 
     def getDependenciesRecursive(self,


### PR DESCRIPTION
set the installed_linked property correctly on the default-location Component (which may be valid in the case it did not match a spec)