### PR TITLE
Updated Ubuntu compiler package versions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -175,13 +175,13 @@ sudo apt-get update
 Install the compiler package for Ubuntu 14.04:
 
 ```sh
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q1-0trusty13
+sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q2-1trusty1
 ```
 
 or for Ubuntu 14.10:
 
 ```sh
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q1-0utopic14
+sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q2-0utopic1
 ```
 
 To use this compiler, you'll need to select a supported cross-compilation


### PR DESCRIPTION
4.9.3.2015q1-0trusty13 has been superseded by version 4.9.3.2015q2-1trusty1
4.9.3.2015q1-0utopic14 has been superseded by version 4.9.3.2015q2-0utopic1
Old package versions not available anymore.