### PR TITLE
Fix for tryReadLink in Windows

### DIFF
--- a/yotta/lib/fsutils_win.py
+++ b/yotta/lib/fsutils_win.py
@@ -28,7 +28,13 @@ def isLink(path):
 
 def tryReadLink(path):
     try:
-        return junction.readlink(path)
+        prevPath = path
+        while isLink(path):
+            path = junction.readlink(path)
+            if path == prevPath: # no idea if this can happen, but why risk it
+                break
+            prevPath = path
+        return path
     except:
         return None
 

--- a/yotta/lib/fsutils_win.py
+++ b/yotta/lib/fsutils_win.py
@@ -28,11 +28,16 @@ def isLink(path):
 
 def tryReadLink(path):
     try:
-        prevPath = path
+        prevPath, initialPath = path, path
+        readlinkCount, maxReadlinkCount = 0, 100
         while isLink(path):
             path = junction.readlink(path)
             if path == prevPath: # no idea if this can happen, but why risk it
                 break
+            # Prevent infinite loop if circular paths are present (A->B->C->A)
+            readlinkCount = readlinkCount + 1
+            if readlinkCount == maxReadlinkCount:
+                return initialPath
             prevPath = path
         return path
     except:


### PR DESCRIPTION
If a link points to another link, tryReadLink won't resolve the link chain
completely in Windows. This commit fixes that.

Before patch:

> yt ls

top_level_module 0.0.1
\_ linked_module_dep 0.0.1 -> C:\Python27\Lib\yotta_modules\linked_module_dep

After patch:

> yt ls

top_level_module 0.0.1
\_ linked_module_dep 0.0.1 -> C:\work\linked_module_dep