### PR TITLE
fixed crash when running yt init with defaults

### DIFF
--- a/yotta/init.py
+++ b/yotta/init.py
@@ -83,7 +83,7 @@ def listOfWords(string):
     if isinstance(string, list):
         return string
     else:
-        return filter(bool, re.split(",|\\s", string))
+        return list(filter(bool, re.split(",|\\s", string)))
 
 def addOptions(parser):
     pass


### PR DESCRIPTION
Another simple fix.

This problem can be re-created by running yt init and pressing enter (without entering any info) untill yotta crashes.