### PR TITLE
Target search fix

### DIFF
--- a/yotta/lib/cache.py
+++ b/yotta/lib/cache.py
@@ -10,39 +10,37 @@ import os
 
 # fsutils, , misc filesystem utils, internal
 import fsutils
+# json, , read / write cache as json 
+import json
 
 # constants
-cache_file = os.path.expanduser('~/.yotta/cache.json')
+cache_location = os.path.expanduser('~/.yotta/cache/')
 
-if os.name == 'nt':
-    cache_file += [
-        os.path.expanduser(os.path.join(folders.prefix(),'cache.json'))
-    ]
+if os.name == 'posix':
+    cache_location = 
 
-# public API
+# public API used to access the "cache"
 
-def get(section):
-    logging.debug("getting %s" %section)
-    with open(cache_file,'r') as f:
-        x = json.load(f)
-        if section in x:
-            logging.debug("value = %s" % x.section)
-            return x.section
-        else:
-            return []
+def get(fname):
+    logging.debug("getting file %s" %fname)
+    #if file exists, return contents
+    if(os.isfile(cache_location+fname)):
+        with open(cache_location,'r') as f:
+            x = json.load(f)
+            logging.debug("Got values: %s" %x)
+            return x
+    # file doesnt exist, return empty dictionary
+    else:
+        logging.debug("file "+fname+" doesnt exist, returning empty dictionary")
+        return []
 
-def getProperty(section, name):
-    logging.debug("getting property %s.%s" % (section , name))
-    return get(section + '.' + name)
+def set(fname, value):
+    logging.debug("setting cache file %s with contents %s" % (fname,value))
+    with open((cache_location+fname),'w+') as f:
+        json.dump(value,f)
+    return
 
-def set(section, value):
-    logging.debug("setting section %s to value %s" % (section,value))
-    with open(cache_file,'rw') as f:
-        x = json.load(f)
-        x.section = value
-        json.dump(x,f)
+
     
-def setProperty(section, name, value):
-    logging.debug("setting property section %s, name %s, value %s" % (section,name,value))
-    set(section+'.'+name, value)
+
 

--- a/yotta/lib/cache.py
+++ b/yotta/lib/cache.py
@@ -19,7 +19,7 @@ import subprocess
 cache_location = os.path.expanduser('~/.yotta/cache/')
 
 #cygwin
-if (os.name == 'posix') and os.environ['OS'] == 'Windows_NT':
+if (os.name == 'posix') and os.environ.get('OS') == 'Windows_NT':
     logging.debug("Cygwin Detected, translating cache_location")
     cache_location = subprocess.check_output(['cygpath','-a','-w',cache_location])
     cache_location = cache_location.replace('\n','')

--- a/yotta/lib/cache.py
+++ b/yotta/lib/cache.py
@@ -18,15 +18,10 @@ from subprocess import call
 # constants
 cache_location = os.path.expanduser('~/.yotta/cache/')
 
-<<<<<<< HEAD
 #if (os.name == 'posix') and os.environ['OS'] == 'Windows_NT':
 #    print("Cygwin Detected, translating cache_location")
 #    #TODO: need to redirect stdout to cache_location to capture the path for cygwin posix conversions
 #    cache_location =  call(["cygpath","-a","-w", cache_location])
-=======
-#if os.name == 'posix':
-#    cache_location = 
->>>>>>> d3c918ad8bbbe05da58ff8fd612f953352eab901
 
 # public API used to access the "cache"
 

--- a/yotta/lib/cache.py
+++ b/yotta/lib/cache.py
@@ -1,0 +1,48 @@
+# Copyright 2014 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library modules, , ,
+import logging
+import os
+#import threading 
+
+# fsutils, , misc filesystem utils, internal
+import fsutils
+
+# constants
+cache_file = os.path.expanduser('~/.yotta/cache.json')
+
+if os.name == 'nt':
+    cache_file += [
+        os.path.expanduser(os.path.join(folders.prefix(),'cache.json'))
+    ]
+
+# public API
+
+def get(section):
+    logging.debug("getting %s" %section)
+    with open(cache_file,'r') as f:
+        x = json.load(f)
+        if section in x:
+            logging.debug("value = %s" % x.section)
+            return x.section
+        else:
+            return []
+
+def getProperty(section, name):
+    logging.debug("getting property %s.%s" % (section , name))
+    return get(section + '.' + name)
+
+def set(section, value):
+    logging.debug("setting section %s to value %s" % (section,value))
+    with open(cache_file,'rw') as f:
+        x = json.load(f)
+        x.section = value
+        json.dump(x,f)
+    
+def setProperty(section, name, value):
+    logging.debug("setting property section %s, name %s, value %s" % (section,name,value))
+    set(section+'.'+name, value)
+

--- a/yotta/lib/cache.py
+++ b/yotta/lib/cache.py
@@ -48,8 +48,3 @@ def set(fname, value):
     with open((cache_location+fname),'w+') as f:
         json.dump(value,f)
     return
-
-
-    
-
-

--- a/yotta/lib/cache.py
+++ b/yotta/lib/cache.py
@@ -12,12 +12,16 @@ import os
 import fsutils
 # json, , read / write cache as json 
 import json
+# call, , used to translate paths using cygpath if you're running cygwin
+from subprocess import call
 
 # constants
 cache_location = os.path.expanduser('~/.yotta/cache/')
 
-if os.name == 'posix':
-    cache_location = 
+#if (os.name == 'posix') and os.environ['OS'] == 'Windows_NT':
+#    print("Cygwin Detected, translating cache_location")
+#    #TODO: need to redirect stdout to cache_location to capture the path for cygwin posix conversions
+#    cache_location =  call(["cygpath","-a","-w", cache_location])
 
 # public API used to access the "cache"
 

--- a/yotta/lib/cache.py
+++ b/yotta/lib/cache.py
@@ -12,16 +12,18 @@ import os
 import fsutils
 # json, , read / write cache as json 
 import json
-# call, , used to translate paths using cygpath if you're running cygwin
-from subprocess import call
+# checklocation, , used to translate paths using cygpath if you're running cygwin
+import subprocess
 
 # constants
 cache_location = os.path.expanduser('~/.yotta/cache/')
 
-#if (os.name == 'posix') and os.environ['OS'] == 'Windows_NT':
-#    print("Cygwin Detected, translating cache_location")
-#    #TODO: need to redirect stdout to cache_location to capture the path for cygwin posix conversions
-#    cache_location =  call(["cygpath","-a","-w", cache_location])
+#cygwin
+if (os.name == 'posix') and os.environ['OS'] == 'Windows_NT':
+    logging.debug("Cygwin Detected, translating cache_location")
+    cache_location = subprocess.check_output(['cygpath','-a','-w',cache_location])
+    cache_location = cache_location.replace('\n','')
+
 
 # public API used to access the "cache"
 
@@ -39,6 +41,9 @@ def get(fname):
         return []
 
 def set(fname, value):
+    if not os.path.exists(cache_location):
+        os.mkdir(cache_location)
+        logging.debug("cache directory didn't exist at <%s> so I created it" %cache_location)
     logging.debug("setting cache file %s with contents %s" % (fname,value))
     with open((cache_location+fname),'w+') as f:
         json.dump(value,f)

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -19,6 +19,7 @@ from functools import reduce
 from .lib import logging_setup
 # detect, , detect things about the system, internal
 from .lib import detect
+import cache
 
 def logLevelFromVerbosity(v):
     return max(1, logging.INFO - v * (logging.ERROR-logging.NOTSET) // 5)
@@ -76,6 +77,13 @@ class FastVersionAction(argparse.Action):
         sys.exit(0)
 
 
+def targetCompletion(prefix, parsed_args, **kwargs):
+    t = cache.get('targets')
+    logging.debug("Target List = %s" %t)
+    # TODO: periodically update targets from here?
+    return(x for x in t if x.startswith(prefix))
+
+
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
@@ -101,7 +109,7 @@ def main():
     parser.add_argument('-t', '--target', dest='target',
         default=detect.defaultTarget(),
         help='Set the build and dependency resolution target (targetname[,versionspec_or_url])'
-    )
+    ).completer = targetCompletion
 
     parser.add_argument('--plain', dest='plain',
         action='store_true', default=False,

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -19,7 +19,9 @@ from functools import reduce
 from .lib import logging_setup
 # detect, , detect things about the system, internal
 from .lib import detect
+import target
 import cache
+from .lib import registry_access
 
 def logLevelFromVerbosity(v):
     return max(1, logging.INFO - v * (logging.ERROR-logging.NOTSET) // 5)
@@ -78,10 +80,11 @@ class FastVersionAction(argparse.Action):
 
 
 def targetCompletion(prefix, parsed_args, **kwargs):
-    t = cache.get('targets')
-    logging.debug("Target List = %s" %t)
-    # TODO: periodically update targets from here?
-    return(x for x in t if x.startswith(prefix))
+    targets = []
+    for result in registry_access.search(query='target', keywords=[], registry=registry_access.Registry_Base_URL):
+        targets.append(result['name'])
+    #cache.set('targets',targets)
+    return(x for x in targets if x.startswith(prefix))
 
 
 def main():

--- a/yotta/target.py
+++ b/yotta/target.py
@@ -33,28 +33,18 @@ Target_RE = re.compile('^('+
     ')?'+
 ')$')
 
-def targetCompletion(prefix, parsed_args, **kwargs):
-    t = cache.get('targets')
-    logging.debug("Target List = %s" %t)
-    print("Trying To Tab Complete... should return the following...")
-    for thing in t:
-        if thing.startswith(prefix):
-            print(thing)
-    return(x for x in t if x.startswith(prefix))
-
 def addOptions(parser):
     parser.add_argument('set_target', default=None, nargs='?',
         help='set the build target to this (targetname[,versionspec_or_url])'
-    ).ChoicesCompleter = targetCompletion
+    )
     parser.add_argument('-g', '--global', dest='save_global',
         default=True, action='store_true',
         help='set globally (in the per-user settings) instead of locally to this directory'
     )
-    parser.add_argument('-u','--updatelocal', 
-        dest='updateLocal', 
-        default=False, action='store_true',
+    parser.add_argument('-u','--updatelocal',
+        dest='updateLocal', default=True,action='store_true',
         help='update the local cache of targets available for tab completion'
-    ).completer = targetCompletion
+    )
 
     # FIXME: need help that lists possible targets, and we need a walkthrough
     # guide to forking a new target for an existing board
@@ -125,13 +115,11 @@ def displayCurrentTarget(args):
 
 
 def execCommand(args, following_args):
+    if args.updateLocal is True:
+        updateTargetList()
     if args.set_target is None:
         return displayCurrentTarget(args)
     else:
-        # TODO: update code so it searches all registries saved to system. (private, public, and local)
-        if args.updateLocal is True:
-            updateTargetList()
-            targetCompletion("frdm",0)            
         if not Target_RE.match(args.set_target):
             logging.error('''Invalid target: "%s"''' % args.set_target)#, targets must be one of:
             #

--- a/yotta/target.py
+++ b/yotta/target.py
@@ -38,7 +38,7 @@ def addOptions(parser):
         help='set the build target to this (targetname[,versionspec_or_url])'
     )
     parser.add_argument('-g', '--global', dest='save_global',
-        default=True, action='store_true',
+        default=False, action='store_true',
         help='set globally (in the per-user settings) instead of locally to this directory'
     )
     parser.add_argument('-u','--updatelocal',


### PR DESCRIPTION
## Problem

manually typing out the target for yotta is a pain and error prone (its entirely possible to set a target that is invalid and you'll never know till you go to compile for it) https://github.com/ARMmbed/yotta/issues/219
## Solution

Added tab completion for the -t --target option. 
## Demo

run `yotta target -u` to update the local cache of targets
run `yotta -t fr<tab>` to have it tab complete (currently to `frdm-k64f-gcc` or `frdm-k64f-armcc`)
## Nitty Gritty

Added cache.py file that creates an basic cachine system in `~/yotta/cache/`, it has two simple access functions, get and set. It leaves all the accessors and pretty stuff up to whatever is using it. All data is stored in un-ordered JSON. If the cache folder doesnt exist it will create it, if the cache file doesnt exist it will create it, if the cache file does exist it will overwrite it (ie a call to cache.set('target',x) followed by a call to cache.set('target',y) would result in the x data being overwritted by the y data. 

The tab completion function accesses the local cache of target names and completes from them. 
## Future improvement

Add zsh tab completions. Add periodic updating of targets cache (maybe the first time the command is run that day? first time every hour? ....?)
