### PR TITLE
add "outdated" subcommand

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -464,3 +464,15 @@ modules when they are built.
 
 See the [config system reference](/reference/config.html) for more details.
 
+<a name="yotta-outdated"></a>
+## yotta outdated
+
+#### Synopsis
+
+```
+yotta outdated
+```
+
+#### Description
+List modules for which newer versions are available from the yotta registry.
+

--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -91,7 +91,7 @@ def tagOrBranchVersion(spec, tags, branches, diagnostic_name):
             return v
     return None
 
-def latestSuitableVersion(name, version_required, registry='modules'):
+def latestSuitableVersion(name, version_required, registry='modules', quiet=False):
     ''' Return a RemoteVersion object representing the latest suitable
         version of the named component or target.
 
@@ -99,8 +99,11 @@ def latestSuitableVersion(name, version_required, registry='modules'):
     '''
 
     remote_component = remoteComponentFor(name, version_required, registry)
-
-    logger.info('get versions for ' + name)
+    
+    if quiet:
+        logger.debug('get versions for ' + name)
+    else:
+        logger.info('get versions for ' + name)
 
     if remote_component.remoteType() == 'registry':
         logger.debug('satisfy %s from %s registry' % (name, registry))

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -167,6 +167,7 @@ def main():
     addParser('login', 'login', 'Authorize for access to private github repositories and publishing to the yotta registry.')
     addParser('logout', 'logout', 'Remove saved authorization token for the current user.')
     addParser('list', 'list', 'List the dependencies of the current module, or the inherited targets of the current target.')
+    addParser('outdated', 'outdated', 'Display information about dependencies which have newer versions available.')
     addParser('uninstall', 'uninstall', 'Remove a specific dependency of the current module, both from module.json and from disk.')
     addParser('remove', 'remove', 'Remove the downloaded version of a dependency, or un-link a linked module.')
     addParser('owners', 'owners', 'Add/remove/display the owners of a module or target.')

--- a/yotta/outdated.py
+++ b/yotta/outdated.py
@@ -31,9 +31,12 @@ def execCommand(args, following_args):
                         test = True
     )
 
-    displayOutdated(dependencies, use_colours=(not args.plain))
+    return displayOutdated(dependencies, use_colours=(not args.plain))
 
 def displayOutdated(modules, use_colours):
+    ''' print information about outdated modules,
+        return 0 if there is nothing to be done and nonzero otherwise
+    '''
     if use_colours:
         DIM    = colorama.Style.DIM
         BRIGHT = colorama.Style.BRIGHT
@@ -43,6 +46,8 @@ def displayOutdated(modules, use_colours):
         RESET  = colorama.Style.RESET_ALL
     else:
         DIM = BRIGHT = YELLOW = RED = RESET = u''
+    
+    status = 0
 
     for name, m in modules.items():
         if m.isTestDependency():
@@ -54,6 +59,7 @@ def displayOutdated(modules, use_colours):
             m_version = DIM + u'@%s' % (m.version)
         if not latest_v:
             print(u'%s%s%s not available from the registry%s' % (RED, name, m_version, RESET))
+            status = 2
             continue
         elif not m or m.version < latest_v:
             if m:
@@ -71,5 +77,8 @@ def displayOutdated(modules, use_colours):
             else:
                 colour = RED
             print(u'%s%s%s latest: %s%s%s' % (name, m_version, RESET, colour, latest_v.version, RESET))
+            if not status:
+                status = 1
+    return status
 
 

--- a/yotta/outdated.py
+++ b/yotta/outdated.py
@@ -1,0 +1,74 @@
+# Copyright 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# colorama, BSD 3-Clause license, cross-platform terminal colours, pip install colorama 
+import colorama
+
+# validate, , validate things, internal
+from .lib import validate
+# access, , get components, internal
+from .lib import access
+
+def addOptions(parser):
+    pass
+
+def execCommand(args, following_args):
+    c = validate.currentDirectoryModule()
+    if not c:
+        return 1
+
+    target, errors = c.satisfyTarget(args.target)
+    if errors:
+        for error in errors:
+            logging.error(error)
+        return 1
+
+    dependencies = c.getDependenciesRecursive(
+                      target = target,
+        available_components = [(c.getName(), c)],
+                        test = True
+    )
+
+    displayOutdated(dependencies, use_colours=(not args.plain))
+
+def displayOutdated(modules, use_colours):
+    if use_colours:
+        DIM    = colorama.Style.DIM
+        BRIGHT = colorama.Style.BRIGHT
+        YELLOW = colorama.Fore.YELLOW
+        RED    = colorama.Fore.RED
+        RESET  = colorama.Style.RESET_ALL
+    else:
+        DIM = BRIGHT = YELLOW = RED = RESET = u''
+
+    for name, m in modules.items():
+        if m.isTestDependency():
+            continue
+        latest_v = access.latestSuitableVersion(name, '*', registry='modules', quiet=True)
+        if not m:
+            m_version = u' ' + RESET + BRIGHT + RED + u"missing" + RESET
+        else:
+            m_version = DIM + u'@%s' % (m.version)
+        if not latest_v:
+            print(u'%s%s%s not available from the registry%s' % (RED, name, m_version, RESET))
+            continue
+        elif not m or m.version < latest_v:
+            if m:
+                if m.version.major() < latest_v.major():
+                    # major versions being outdated might be deliberate, so not
+                    # that bad:
+                    colour = u''
+                elif m.version.minor() < latest_v.minor():
+                    # minor outdated versions is moderately bad
+                    colour = YELLOW
+                else:
+                    # patch-outdated versions is really bad, because there should
+                    # be no reason not to update:
+                    colour = RED
+            else:
+                colour = RED
+            print(u'%s%s%s latest: %s%s%s' % (name, m_version, RESET, colour, latest_v.version, RESET))
+
+

--- a/yotta/outdated.py
+++ b/yotta/outdated.py
@@ -39,6 +39,7 @@ def displayOutdated(modules, use_colours):
         BRIGHT = colorama.Style.BRIGHT
         YELLOW = colorama.Fore.YELLOW
         RED    = colorama.Fore.RED
+        GREEN  = colorama.Fore.GREEN
         RESET  = colorama.Style.RESET_ALL
     else:
         DIM = BRIGHT = YELLOW = RED = RESET = u''
@@ -59,7 +60,7 @@ def displayOutdated(modules, use_colours):
                 if m.version.major() < latest_v.major():
                     # major versions being outdated might be deliberate, so not
                     # that bad:
-                    colour = u''
+                    colour = GREEN
                 elif m.version.minor() < latest_v.minor():
                     # minor outdated versions is moderately bad
                     colour = YELLOW

--- a/yotta/test/cli/outdated.py
+++ b/yotta/test/cli/outdated.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# Copyright 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library modules, , ,
+import unittest
+import os
+import tempfile
+import copy
+
+# internal modules:
+from yotta.lib.fsutils import mkDirP, rmRf
+from yotta.lib.detect import systemDefaultTarget
+from . import cli
+
+Test_Outdated = {
+'module.json':'''{
+  "name": "test-outdated",
+  "version": "0.0.0",
+  "description": "Test yotta outdated",
+  "author": "James Crosby <james.crosby@arm.com>",
+  "license": "Apache-2.0",
+  "dependencies":{
+    "test-testing-dummy": "*"
+  }
+}''',
+'source/foo.c':'''#include "stdio.h"
+int foo(){
+    printf("foo!\\n");
+    return 7;
+}''',
+# test-testing-dummy v0.0.1 (a newer version is available from the registry,
+# and will be installed by yt up)
+'yotta_modules/test-testing-dummy/module.json':'''{
+  "name": "test-testing-dummy",
+  "version": "0.0.1",
+  "description": "Test yotta's compilation of tests.",
+  "author": "James Crosby <james.crosby@arm.com>",
+  "license": "Apache-2.0"
+}
+'''
+}
+
+class TestCLIOutdated(unittest.TestCase):
+    def writeTestFiles(self, files, add_space_in_path=False):
+        test_dir = tempfile.mkdtemp()
+        if add_space_in_path:
+            test_dir = test_dir + ' spaces in path'
+
+        for path, contents in files.items():
+            path_dir, file_name =  os.path.split(path)
+            path_dir = os.path.join(test_dir, path_dir)
+            mkDirP(path_dir)
+            with open(os.path.join(path_dir, file_name), 'w') as f:
+                f.write(contents)
+        return test_dir
+
+    def test_outdated(self):
+        path = self.writeTestFiles(Test_Outdated, True)
+        
+        stdout, stderr, statuscode = cli.run(['-t', 'x86-linux-native', 'outdated'], cwd=path)
+        self.assertNotEqual(statuscode, 0)
+        self.assertIn('test-testing-dummy', stdout + stderr)
+
+        rmRf(path)
+
+    def test_notOutdated(self):
+        path = self.writeTestFiles(Test_Outdated, True)
+        
+        stdout, stderr, statuscode = cli.run(['-t', 'x86-linux-native', 'up'], cwd=path)
+        self.assertEqual(statuscode, 0)
+
+        stdout, stderr, statuscode = cli.run(['-t', 'x86-linux-native', 'outdated'], cwd=path)
+        self.assertEqual(statuscode, 0)
+        self.assertNotIn('test-testing-dummy', stdout + stderr)
+
+        rmRf(path)


### PR DESCRIPTION
A very simple version for now.

This goes towards resolving #117, but to completely close that issue, `yotta outdated` should be able to tell you why modules aren't being updated by `yotta up` (which it can't do yet)