### PR TITLE
Add a newline at the end of json files when writing them.

### DIFF
--- a/yotta/lib/ordered_json.py
+++ b/yotta/lib/ordered_json.py
@@ -23,6 +23,7 @@ def dump(path, obj):
     with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR), 'w') as f:
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
         json.dump(obj, f, indent=2, separators=(',', ': '))
+        f.write(u'\n')
         f.truncate()
 
 def loads(string):


### PR DESCRIPTION
This fixes the really irritating ping-pong of newline/nonewline when editing
json files with an editor, and with `yotta version` commands.