### PR TITLE
Adds intelhex dependency for nordic targets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'jsonschema>=2.4.0,<3.0',
         'argcomplete>=0.8.0,<1.0',
         'mbed_test_wrapper>=0.0.2,<0.1.0',
-        'valinor>=0.0.0,<1.0'
+        'valinor>=0.0.0,<1.0',
+        'intelhex>=2.0,<3.0'
     ] + platform_deps
 )


### PR DESCRIPTION
This removes the need for SRecord for merging the nordic soft device with binaries. Now uses a pip installable module called 'intelhex'. See https://github.com/ARMmbed/target-nrf51822/pull/9 for more information with regard to the nordic targets.