### PR TITLE
Add noninteractive mode

### DIFF
--- a/yotta/lib/auth.py
+++ b/yotta/lib/auth.py
@@ -1,0 +1,110 @@
+# Copyright 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library modules, , ,
+import logging
+import sys
+import os
+import datetime
+import time
+import webbrowser
+
+# colorama, BSD 3-Clause license, cross-platform terminal colours, pip install colorama 
+import colorama
+
+# Registry Access, , access packages in the registry, internal
+import registry_access
+# settings, , load and save settings, internal
+import settings
+
+logger = logging.getLogger('access')
+
+def _pollForAuth(registry=None):
+    tokens = registry_access.getAuthData(registry=registry)
+    if tokens:
+        if 'github' in tokens:
+            settings.setProperty('github', 'authtoken', tokens['github'])
+        # mbed login doesn't send us a token
+        return True
+    return False
+
+
+def _openBrowserLogin(provider=None, registry=None):
+    webbrowser.open(registry_access.getLoginURL(provider=provider, registry=registry))
+
+def authorizeUser(registry=None, provider='github', interactive=True):
+    # poll once with any existing public key, just in case a previous login
+    # attempt was interrupted after it completed
+    try:
+        if _pollForAuth(registry=registry):
+            return
+    except registry_access.AuthError as e:
+        logger.error('%s' % e)
+        return
+
+    # python 2 + 3 compatibility
+    try:
+        global input
+        input = raw_input
+    except NameError:
+        pass
+    
+    if interactive:
+        login_instruction = '\nYou need to log in to do this.\n'
+        if provider == 'github':
+            login_instruction = '\nYou need to log in with Github to do this.\n'
+
+        sys.stdout.write(login_instruction)
+    
+        if os.name == 'nt' or os.environ.get('DISPLAY'):
+            input(
+                colorama.Style.BRIGHT+
+                'Press enter to continue.\n'+
+                colorama.Style.DIM+
+                'Your browser will open to complete login.'+
+                colorama.Style.NORMAL+'\n'
+            )
+
+            _openBrowserLogin(provider=provider, registry=registry)
+
+            sys.stdout.write('waiting for response...')
+            sys.stdout.write(
+                colorama.Style.DIM+
+                '\nIf you are unable to use a browser on this machine, please copy and '+
+                'paste this URL into a browser:\n'+
+                registry_access.getLoginURL(provider=provider, registry=registry)+'\n'+
+                colorama.Style.NORMAL
+            )
+            sys.stdout.flush()
+        else:
+            sys.stdout.write(
+                '\nyotta is unable to open a browser for you to complete login '+
+                'on this machine. Please copy and paste this URL into a '
+                'browser to complete login:\n'+
+                registry_access.getLoginURL(provider=provider, registry=registry)+'\n'
+            )
+            sys.stdout.write('waiting for response...')
+            sys.stdout.flush()
+
+        poll_start = datetime.datetime.utcnow()
+        while datetime.datetime.utcnow() - poll_start < datetime.timedelta(minutes=5):
+            time.sleep(5)
+            sys.stdout.write('.')
+            sys.stdout.flush()
+            try:
+                if _pollForAuth(registry=registry):
+                    sys.stdout.write('\n')
+                    return
+            except registry_access.AuthError as e:
+                logger.error('%s' % e)
+                return
+        raise Exception('Login timed out: please try again.')
+
+    else:
+        logger.error('login required (yotta is running in noninteractive mode)')
+        logger.info('login URL: %s', registry_access.getLoginURL(provider=provider, registry=registry))
+    
+
+

--- a/yotta/lib/github_access.py
+++ b/yotta/lib/github_access.py
@@ -27,7 +27,7 @@ import registry_access
 # auth, , authenticate users, internal
 import auth
 # globalconf, share global arguments between modules, internal
-import globalconf
+import yotta.lib.globalconf as globalconf
 
 # Constants
 _github_url = 'https://api.github.com'

--- a/yotta/lib/github_access.py
+++ b/yotta/lib/github_access.py
@@ -7,12 +7,14 @@
 import logging
 import json
 import getpass
-import os
 import re
 import functools
-import datetime
-import time
-import sys
+
+# requests, apache2
+import requests
+# PyGithub, LGPL, Python library for Github API v3, pip install PyGithub
+import github
+from github import Github
 
 # settings, , load and save settings, internal
 import settings
@@ -22,16 +24,10 @@ import version
 import access_common
 # Registry Access, , access packages in the registry, internal
 import registry_access
-
-# colorama, BSD 3-Clause license, cross-platform terminal colours, pip install colorama 
-import colorama
-
-# requests, apache2
-import requests
-
-# PyGithub, LGPL, Python library for Github API v3, pip install PyGithub
-import github
-from github import Github
+# auth, , authenticate users, internal
+import auth
+# globalconf, share global arguments between modules, internal
+import globalconf
 
 # Constants
 _github_url = 'https://api.github.com'
@@ -46,38 +42,58 @@ logger = logging.getLogger('access')
 
 # Internal functions
 
-def _userAuthorized():
+def _userAuthedWithGithub():
     return settings.getProperty('github', 'authtoken')
  
 def _handleAuth(fn):
     ''' Decorator to re-try API calls after asking the user for authentication. '''
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
-        try:
-            return fn(*args, **kwargs)
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 401:
-                authorizeUser()
+        # if yotta is being run noninteractively, then we never retry, but we
+        # do call auth.authorizeUser, so that a login URL can be displayed:
+        interactive = globalconf.get('interactive')
+        if not interactive:
+            try:
                 return fn(*args, **kwargs)
-            else:
+            except requests.exceptions.HTTPError as e:
+                if e.response.status_code == 401:
+                    auth.authorizeUser(provider='github', interactive=False)
                 raise
-        except github.BadCredentialsException:
-            logger.debug("github: bad credentials")
-            authorizeUser()
-            logger.debug('trying with authtoken:', settings.getProperty('github', 'authtoken'))
-            return fn(*args, **kwargs)
-        except github.UnknownObjectException:
-            logger.debug("github: unknown object")
-            # some endpoints return 404 if the user doesn't have access, maybe
-            # it would be better to prompt for another username and password,
-            # and store multiple tokens that we can try for each request....
-            # but for now we assume that if the user is logged in then a 404
-            # really is a 404
-            if not _userAuthorized():
-                logger.info('failed to fetch Github object, re-trying with authentication...')
-                authorizeUser()
+            except github.BadCredentialsException:
+                logger.debug("github: bad credentials")
+                auth.authorizeUser(provider='github', interactive=False)
+                raise
+            except github.UnknownObjectException:
+                logger.debug("github: unknown object")
+                # some endpoints return 404 if the user doesn't have access:
+                if not _userAuthedWithGithub():
+                    logger.info('failed to fetch Github object, try re-authing...')
+                    auth.authorizeUser(provider='github', interactive=False)
+                raise
+        else:
+            try:
                 return fn(*args, **kwargs)
-            else:
+            except requests.exceptions.HTTPError as e:
+                if e.response.status_code == 401:
+                    auth.authorizeUser(provider='github')
+                    return fn(*args, **kwargs)
+                raise
+            except github.BadCredentialsException:
+                logger.debug("github: bad credentials")
+                auth.authorizeUser(provider='github')
+                logger.debug('trying with authtoken:', settings.getProperty('github', 'authtoken'))
+                return fn(*args, **kwargs)
+            except github.UnknownObjectException:
+                logger.debug("github: unknown object")
+                # some endpoints return 404 if the user doesn't have access, maybe
+                # it would be better to prompt for another username and password,
+                # and store multiple tokens that we can try for each request....
+                # but for now we assume that if the user is logged in then a 404
+                # really is a 404
+                if not _userAuthedWithGithub():
+                    logger.info('failed to fetch Github object, re-trying with authentication...')
+                    auth.authorizeUser(provider='github')
+                    return fn(*args, **kwargs)
                 raise
     return wrapped
 
@@ -131,85 +147,7 @@ def _getTarball(url, into_directory):
 
     access_common.unpackTarballStream(response, into_directory)
 
-def _pollForAuth(registry=None):
-    tokens = registry_access.getAuthData(registry=registry)
-    if tokens:
-        if 'github' in tokens:
-            settings.setProperty('github', 'authtoken', tokens['github'])
-        # mbed login doesn't send us a token
-        return True
-    return False
-
 # API
-def authorizeUser(registry=None, provider='github'):
-    # poll once with any existing public key, just in case a previous login
-    # attempt was interrupted after it completed
-    try:
-        if _pollForAuth(registry=registry):
-            return
-    except registry_access.AuthError as e:
-        logger.error('%s' % e)
-        return
-
-    # python 2 + 3 compatibility
-    try:
-        global input
-        input = raw_input
-    except NameError:
-        pass
-    
-    login_instruction = '\nYou need to log in to do this.\n'
-    if provider == 'github':
-        login_instruction = '\nYou need to log in with Github to do this.\n'
-
-    sys.stdout.write(login_instruction)
-    
-    if os.name == 'nt' or os.environ.get('DISPLAY'):
-        input(
-            colorama.Style.BRIGHT+
-            'Press enter to continue.\n'+
-            colorama.Style.DIM+
-            'Your browser will open to complete login.'+
-            colorama.Style.NORMAL+'\n'
-        )
-
-        registry_access.openBrowserLogin(provider=provider, registry=registry)
-        
-
-        sys.stdout.write('waiting for response...')
-        sys.stdout.write(
-            colorama.Style.DIM+
-            '\nIf you are unable to use a browser on this machine, please copy and '+
-            'paste this URL into a browser:\n'+
-            registry_access.getLoginURL(provider=provider, registry=registry)+'\n'+
-            colorama.Style.NORMAL
-        )
-        sys.stdout.flush()
-    else:
-        sys.stdout.write(
-            '\nyotta is unable to open a browser for you to complete login '+
-            'on this machine. Please copy and paste this URL into a '
-            'browser to complete login:\n'+
-            registry_access.getLoginURL(provider=provider, registry=registry)+'\n'
-        )
-        sys.stdout.write('waiting for response...')
-        sys.stdout.flush()
-
-    poll_start = datetime.datetime.utcnow()
-    while datetime.datetime.utcnow() - poll_start < datetime.timedelta(minutes=5):
-        time.sleep(5)
-        sys.stdout.write('.')
-        sys.stdout.flush()
-        try:
-            if _pollForAuth(registry=registry):
-                sys.stdout.write('\n')
-                return
-        except registry_access.AuthError as e:
-            logger.error('%s' % e)
-            return
-
-    raise Exception('Login timed out: please try again.')
-
 def deauthorize():
     if settings.getProperty('github', 'authtoken'):
         settings.setProperty('github', 'authtoken', '')

--- a/yotta/lib/globalconf.py
+++ b/yotta/lib/globalconf.py
@@ -1,0 +1,17 @@
+# Copyright 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# this module exists to share global config amongst modules
+
+conf = {}
+
+def set(name, value):
+    global conf
+    conf[name] = value
+
+def get(name):
+    global conf
+    return conf[name]
+

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -48,7 +48,7 @@ import exportkey
 # auth, , authenticate users, internal
 import auth
 # globalconf, share global arguments between modules, internal
-import globalconf
+import yotta.lib.globalconf as globalconf
 
 Registry_Base_URL = 'https://registry.yottabuild.org'
 Registry_Auth_Audience = 'http://registry.yottabuild.org'
@@ -461,7 +461,7 @@ def unpublish(namespace, name, version, registry=None):
 @_swallowRequestExceptions(fail_return=None)
 @_friendlyAuthError
 @_handleAuth
-def listOwners(namespace, name, registry=None, interactive=True):
+def listOwners(namespace, name, registry=None):
     ''' List the owners of a module or target (owners are the people with
         permission to publish versions and add/remove the owners). 
     '''
@@ -490,7 +490,7 @@ def listOwners(namespace, name, registry=None, interactive=True):
 @_swallowRequestExceptions(fail_return=None)
 @_friendlyAuthError
 @_handleAuth
-def addOwner(namespace, name, owner, registry=None, interactive=True):
+def addOwner(namespace, name, owner, registry=None):
     ''' Add an owner for a module or target (owners are the people with
         permission to publish versions and add/remove the owners). 
     '''
@@ -519,7 +519,7 @@ def addOwner(namespace, name, owner, registry=None, interactive=True):
 @_swallowRequestExceptions(fail_return=None)
 @_friendlyAuthError
 @_handleAuth
-def removeOwner(namespace, name, owner, registry=None, interactive=True):
+def removeOwner(namespace, name, owner, registry=None):
     ''' Remove an owner for a module or target (owners are the people with
         permission to publish versions and add/remove the owners). 
     '''

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -515,6 +515,8 @@ def addOwner(namespace, name, owner, registry=None):
     # re-try if appropriate
     response.raise_for_status()
 
+    return True
+
 
 @_swallowRequestExceptions(fail_return=None)
 @_friendlyAuthError
@@ -543,6 +545,8 @@ def removeOwner(namespace, name, owner, registry=None):
     # raise exceptions for other errors - the auth decorators handle these and
     # re-try if appropriate
     response.raise_for_status()
+
+    return True
 
 
 def search(query='', keywords=[], registry=None):

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -16,7 +16,6 @@ import datetime
 import hashlib
 import itertools
 import base64
-import webbrowser
 import os
 try:
     from urllib import quote as quoteURL
@@ -46,6 +45,10 @@ import ordered_json
 import github_access
 # export key, , export pycrypto keys, internal
 import exportkey
+# auth, , authenticate users, internal
+import auth
+# globalconf, share global arguments between modules, internal
+import globalconf
 
 Registry_Base_URL = 'https://registry.yottabuild.org'
 Registry_Auth_Audience = 'http://registry.yottabuild.org'
@@ -112,17 +115,20 @@ def _handleAuth(fn):
     ''' Decorator to re-try API calls after asking the user for authentication. '''
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
+        # if yotta is being run noninteractively, then we never retry, but we
+        # do call auth.authorizeUser, so that a login URL can be displayed:
+        interactive = globalconf.get('interactive')
         try:
             return fn(*args, **kwargs)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == requests.codes.unauthorized:
                 logger.debug('%s unauthorised', fn)
                 # any provider is sufficient for registry auth
-                github_access.authorizeUser(provider=None)
-                logger.debug('retrying after authentication...')
-                return fn(*args, **kwargs)
-            else:
-                raise
+                auth.authorizeUser(provider=None, interactive=interactive)
+                if interactive:
+                    logger.debug('retrying after authentication...')
+                    return fn(*args, **kwargs)
+            raise
     return wrapped
 
 def _friendlyAuthError(fn):
@@ -136,10 +142,24 @@ def _friendlyAuthError(fn):
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == requests.codes.unauthorized:
                 logger.error('insufficient permission')
-                return None
             else:
-                raise
+                logger.error('server returned status %s: %s', e.response.status_code, e.response.text)
+            raise
     return wrapped
+
+def _swallowRequestExceptions(fail_return=None):
+    def __swallowRequestExceptions(fn):
+        ''' Decorator to swallow known exceptions: use with _friendlyAuthError,
+            returns non-None if an exception occurred
+        '''
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            except requests.exceptions.HTTPError as e:
+                return fail_return
+        return wrapped
+    return __swallowRequestExceptions
 
 def _getPrivateRegistryKey():
     if 'YOTTA_PRIVATE_REGISTRY_API_KEY' in os.environ:
@@ -378,6 +398,8 @@ class RegistryThing(access_common.RemoteComponent):
     def remoteType(cls):
         return 'registry'
 
+@_swallowRequestExceptions(fail_return="request exception occurred")
+@_friendlyAuthError
 @_handleAuth
 def publish(namespace, name, version, description_file, tar_file, readme_file,
             readme_file_ext, registry=None):
@@ -410,12 +432,12 @@ def publish(namespace, name, version, description_file, tar_file, readme_file,
     headers = _headersForRegistry(registry)
     
     response = requests.put(url, headers=headers, files=body)
-
-    if not response.ok:
-        return "server returned status %s: %s" % (response.status_code, response.text)
+    response.raise_for_status()
 
     return None
 
+@_swallowRequestExceptions(fail_return="request exception occurred")
+@_friendlyAuthError
 @_handleAuth
 def unpublish(namespace, name, version, registry=None):
     ''' Try to unpublish a recently published version. Return any errors that
@@ -432,15 +454,14 @@ def unpublish(namespace, name, version, registry=None):
     
     headers = _headersForRegistry(registry)
     response = requests.delete(url, headers=headers)
-
-    if not response.ok:
-        return "server returned status %s: %s" % (response.status_code, response.text)
+    response.raise_for_status()
 
     return None
 
+@_swallowRequestExceptions(fail_return=None)
 @_friendlyAuthError
 @_handleAuth
-def listOwners(namespace, name, registry=None):
+def listOwners(namespace, name, registry=None, interactive=True):
     ''' List the owners of a module or target (owners are the people with
         permission to publish versions and add/remove the owners). 
     '''
@@ -458,7 +479,7 @@ def listOwners(namespace, name, registry=None):
 
     if response.status_code == 404:
         logger.error('no such %s, "%s"' % (namespace[:-1], name))
-        return []
+        return None
     
     # raise exceptions for other errors - the auth decorators handle these and
     # re-try if appropriate
@@ -466,9 +487,10 @@ def listOwners(namespace, name, registry=None):
 
     return ordered_json.loads(response.text)
 
+@_swallowRequestExceptions(fail_return=None)
 @_friendlyAuthError
 @_handleAuth
-def addOwner(namespace, name, owner, registry=None):
+def addOwner(namespace, name, owner, registry=None, interactive=True):
     ''' Add an owner for a module or target (owners are the people with
         permission to publish versions and add/remove the owners). 
     '''
@@ -494,9 +516,10 @@ def addOwner(namespace, name, owner, registry=None):
     response.raise_for_status()
 
 
+@_swallowRequestExceptions(fail_return=None)
 @_friendlyAuthError
 @_handleAuth
-def removeOwner(namespace, name, owner, registry=None):
+def removeOwner(namespace, name, owner, registry=None, interactive=True):
     ''' Remove an owner for a module or target (owners are the people with
         permission to publish versions and add/remove the owners). 
     '''
@@ -685,6 +708,3 @@ def getLoginURL(provider=None, registry=None):
         query += '&private=1'
     return  Website_Base_URL + '/' + query + '#login/' + getPublicKey(registry)
 
-def openBrowserLogin(provider=None, registry=None):
-    registry = registry or Registry_Base_URL    
-    webbrowser.open(getLoginURL(provider=provider, registry=registry))

--- a/yotta/login.py
+++ b/yotta/login.py
@@ -6,8 +6,8 @@
 # standard library modules, , ,
 import argparse
 
-# Github Access, , access repositories on github, internal
-from .lib import github_access
+# auth, , authenticate users, internal
+from .lib import auth
 # Registry Access, , access modules in the registry, internal
 from .lib import registry_access
 
@@ -21,6 +21,6 @@ def addOptions(parser):
 def execCommand(args, following_args):
     if args.apikey:
         registry_access.setAPIKey(args.registry, args.apikey)
-
-    github_access.authorizeUser(args.registry, provider=None)
+    
+    auth.authorizeUser(args.registry, provider=None, interactive=args.interactive)
 

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -19,6 +19,8 @@ from functools import reduce
 from .lib import logging_setup
 # detect, , detect things about the system, internal
 from .lib import detect
+# globalconf, share global arguments between modules, internal
+from .lib import globalconf
 
 def logLevelFromVerbosity(v):
     return max(1, logging.INFO - v * (logging.ERROR-logging.NOTSET) // 5)
@@ -106,6 +108,11 @@ def main():
     parser.add_argument('--plain', dest='plain',
         action='store_true', default=False,
         help="Use a simple output format with no colours"
+    )
+
+    parser.add_argument('--noninteractive', '-n', dest='interactive',
+        action='store_false', default=True,
+        help="Do not wait for user interaction (for example to log in), fail instead."
     )
 
     parser.add_argument(
@@ -205,6 +212,10 @@ def main():
     # when args are passed directly we need to strip off the program name
     # (hence [:1])
     args = parser.parse_args(split_args[0][1:])
+    
+    # set global arguments that are shared everywhere and never change
+    globalconf.set('interactive', args.interactive)
+    globalconf.set('plain', args.plain)
 
     loglevel = logLevelFromVerbosity(args.verbosity)
     logging_setup.init(level=loglevel, enable_subsystems=args.debug, plain=args.plain)

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -20,7 +20,7 @@ from .lib import logging_setup
 # detect, , detect things about the system, internal
 from .lib import detect
 # globalconf, share global arguments between modules, internal
-from .lib import globalconf
+import yotta.lib.globalconf as globalconf
 
 def logLevelFromVerbosity(v):
     return max(1, logging.INFO - v * (logging.ERROR-logging.NOTSET) // 5)

--- a/yotta/owners.py
+++ b/yotta/owners.py
@@ -79,11 +79,11 @@ def execCommand(args, following_args):
         return 1
 
     if sc in ('list', 'ls', ''):
-        listOwners(args, p)
+        return listOwners(args, p)
     elif sc in ('remove', 'rm'):
-        removeOwner(args, p)
+        return removeOwner(args, p)
     elif sc in ('add',):
-        addOwner(args, p)
+        return addOwner(args, p)
 
 
 def listOwners(args, p):
@@ -91,6 +91,8 @@ def listOwners(args, p):
         owners = registry_access.listOwners(p.getRegistryNamespace(), p.getName(), registry=args.registry)
         if owners is not None:
             print('%s "%s" owners:' % (p.getRegistryNamespace(), p.getName()), ', '.join(owners))
+        else:
+            return 1
     else:
         module_owners = registry_access.listOwners(component.Registry_Namespace, args.module, registry=args.registry)
         target_owners = registry_access.listOwners(target.Registry_Namespace, args.module, registry=args.registry)
@@ -100,17 +102,21 @@ def listOwners(args, p):
             print('target "%s" owners:' % args.module, ', '.join(target_owners))
         if not module_owners and not target_owners:
             logging.error('no such module or target')
+            return 1
+    return 0
 
 def removeOwner(args, p):
     if p:
-        registry_access.removeOwner(p.getRegistryNamespace(), p.getName(), args.email, registry=args.registry)
+        success = registry_access.removeOwner(p.getRegistryNamespace(), p.getName(), args.email, registry=args.registry)
     else:
         # !!! FIXME: test which of target/component exist first
-        registry_access.removeOwner(component.Registry_Namespace, args.module, args.email, registry=args.registry)
+        success = registry_access.removeOwner(component.Registry_Namespace, args.module, args.email, registry=args.registry)
+    return 0 if success else 1
 
 def addOwner(args, p):
     if p:
-        registry_access.addOwner(p.getRegistryNamespace(), p.getName(), args.email, registry=args.registry)
+        success = registry_access.addOwner(p.getRegistryNamespace(), p.getName(), args.email, registry=args.registry)
     else:
         # !!! FIXME: test which of target/component exist first
-        registry_access.addOwner(component.Registry_Namespace, args.module, args.email, registry=args.registry)
+        success = registry_access.addOwner(component.Registry_Namespace, args.module, args.email, registry=args.registry)
+    return 0 if success else 1

--- a/yotta/test/cli/owners.py
+++ b/yotta/test/cli/owners.py
@@ -43,16 +43,23 @@ class TestCLIOwners(unittest.TestCase):
     def tearDown(self):
         rmRf(self.test_dir)
 
-    # you have have to be authenticated to list owners, so this doesn't work
-    # yet...
-    #def test_listOwners(self):
-    #    stdout = self.runCheckCommand(['owners', 'ls'])
-    #    self.assertTrue(stdout.find('autopulated@gmail.com') != -1)
+    # you have have to be authenticated to list owners, so currently we only
+    # test that the commands fail correctly in noninteractive mode:
 
-    def runCheckCommand(self, args):
-        stdout, stderr, statuscode = cli.run(args, cwd=self.test_dir)
-        self.assertEqual(statuscode, 0)
-        return stdout or stderr
+    def test_listOwners(self):
+        stdout, stderr, statuscode = cli.run(['-n', 'owners', 'ls'], cwd=self.test_dir)
+        self.assertTrue((stdout+stderr).find('login required') != -1)
+        self.assertNotEqual(statuscode, 0)
+
+    def test_addOwner(self):
+        stdout, stderr, statuscode = cli.run(['-n', 'owners', 'add', 'friend@example.com'], cwd=self.test_dir)
+        self.assertTrue((stdout+stderr).find('login required') != -1)
+        self.assertNotEqual(statuscode, 0)
+
+    def test_rmOwner(self):
+        stdout, stderr, statuscode = cli.run(['-n', 'owners', 'rm', 'friend@example.com'], cwd=self.test_dir)
+        self.assertTrue((stdout+stderr).find('login required') != -1)
+        self.assertNotEqual(statuscode, 0)
 
 
 if __name__ == '__main__':

--- a/yotta/test/cli/publish.py
+++ b/yotta/test/cli/publish.py
@@ -52,6 +52,13 @@ Private_Module_JSON = '''{
 }
 '''
 
+Public_Module_JSON = '''{
+  "name": "testmod",
+  "version": "0.0.0",
+  "license": "Apache-2.0"
+}'''
+
+
 class TestCLIPublish(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
@@ -66,6 +73,12 @@ class TestCLIPublish(unittest.TestCase):
         self.assertNotEqual(status, 0)
         self.assertTrue('is private and cannot be published' in ('%s %s' % (stdout, stderr)))
 
+    def test_publishNotAuthed(self):
+        with open(os.path.join(self.test_dir, 'module.json'), 'w') as f:
+            f.write(Public_Module_JSON)
+        stdout, stderr, status = cli.run(['-n', '--target', Test_Target, 'publish'], cwd=self.test_dir)
+        self.assertTrue((stdout+stderr).find('login required') != -1)
+        self.assertNotEqual(status, 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Activated by -n/--noninteractive. If authentication is required in
noninteractive mode, then a message like this will be displayed:

> error: login required (yotta is running in noninteractive mode)
> info: login URL: http://yottabuild.org/#login/abcde....

If multiple requests that yotta tried to perform require authentication, then
this might be displayed several times.

To make this possible, the way that some errors are handled in the
registry_access module has been adjusted, and the auth logic has been moved out
of github_access (where it didn't belong anyway) into a separate module.

Fixes #378

@thegecko 