### PR TITLE
Permit scope resolution for config in targetDependencies

### DIFF
--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -110,7 +110,7 @@
         "targetDependencies": {
             "type": "object",
             "patternProperties": {
-                "(^[a-z]+[a-z0-9-]*$)|(^[*]$)": {
+                "(^[a-z]+[a-z0-9-.]*$)|(^[*]$)": {
                     "$ref": "#/definitions/dependencyMap"
                 }
             },

--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -119,7 +119,7 @@
         "testTargetDependencies": {
             "type": "object",
             "patternProperties": {
-                "(^[a-z]+[a-z0-9-]*$)|(^[*]$)": {
+                "(^[a-z]+[a-z0-9-.]*$)|(^[*]$)": {
                     "$ref": "#/definitions/dependencyMap"
                 }
             },


### PR DESCRIPTION
Yotta warns when using scoped config entries in targetDependencies.  Add the `.` character to patternProperties to permit scoped properties.