### PR TITLE
ensure that include directories of test dependencies are absolute

### DIFF
--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -37,6 +37,7 @@ def sanitizeSymbol(sym):
 jinja_environment.filters['replaceBackslashes'] = replaceBackslashes
 jinja_environment.filters['sanitizePreprocessorSymbol'] = sanitizePreprocessorSymbol
 jinja_environment.globals['list'] = list
+jinja_environment.globals['pathJoin'] = os.path.join
 
 class SourceFile(object):
     def __init__(self, fullpath, relpath, lang):

--- a/yotta/lib/templates/test_CMakeLists.txt
+++ b/yotta/lib/templates/test_CMakeLists.txt
@@ -10,13 +10,13 @@ include_directories("{{ source_directory | replaceBackslashes }}")
 
 {% for component in test_dependencies %}
     {% for d in component.getExtraSysIncludes() %}
-        include_directories(SYSTEM "{{ d | replaceBackslashes }}")
+        include_directories(SYSTEM "{{ pathJoin(component.path, d) | replaceBackslashes }}")
     {% endfor %}
 {% endfor %}
 
 {% for component in test_dependencies %}
     {% for d in component.getExtraIncludes() %}
-        include_directories("{{ d | replaceBackslashes }}")
+        include_directories("{{ pathJoin(component.path, d) | replaceBackslashes }}")
     {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
Fix case where testDependencies with additional include directories specified would fail to compile.

Possibly fixes #409 

@rgrover please confirm if this resolves your issue. It resolves everything that I can reproduce, but shouldn't technically have changed anything related to linking.