### PR TITLE
Make CMakeLists generated support qtcreator.

### DIFF
--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -179,7 +179,6 @@ class CMakeGen(object):
                 headers = self.containsSourceFiles(os.path.join(component.path, f), component)
                 if headers:
                     header_subdirs.append((f, headers))
-                    print("dir: %s, headers: %r" % (f, headers))
 
             elif f in ('resource'):
                 resource_subdirs.append(os.path.join(component.path, f))

--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -104,8 +104,6 @@ add_subdirectory(
 # add_subdirectory because the directories referred to here exist in the source
 # tree, not the working directory
 
-MESSAGE( STATUS "CMAKE_BINARY_DIR:         " ${CMAKE_BINARY_DIR} )
-
 {% for srcdir, workingdir in add_own_subdirs %}
 #add_subdirectory(
 #    "{{ srcdir | replaceBackslashes }}"

--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -110,10 +110,17 @@ add_subdirectory(
 # recurse into subdirectories for this component, using the two-argument
 # add_subdirectory because the directories referred to here exist in the source
 # tree, not the working directory
+
+MESSAGE( STATUS "CMAKE_BINARY_DIR:         " ${CMAKE_BINARY_DIR} )
+
 {% for srcdir, workingdir in add_own_subdirs %}
+#add_subdirectory(
+#    "{{ srcdir | replaceBackslashes }}"
+#    "{{ workingdir | replaceBackslashes }}"
+#)
 add_subdirectory(
     "{{ srcdir | replaceBackslashes }}"
-    "{{ workingdir | replaceBackslashes }}"
+    "${CMAKE_BINARY_DIR}/{{ relpath | replaceBackslashes }}/{{ workingdir | replaceBackslashes }}"
 )
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
QtCreator can open the CMakeLists file generated by yotta, 

but the project view doesn't display the header files when they are not  source files belong to any target.

So, the new CMakeLists file like this:

```cmake
set(YOTTA_AUTO_MINAR_CPP_FILES
    "project_path/yotta_modules/minar/source/minar.cpp"
)
set(YOTTA_AUTO_MINAR_HEADER_FILES
    "project_path/yotta_modules/minar/minar/minar.h"
)

add_library(minar
    ${YOTTA_AUTO_MINAR_CPP_FILES}
    ${YOTTA_AUTO_MINAR_HEADER_FILES}
)
```

Mbed CODING and BUILDING with QtCreator is awesome!
![image](https://cloud.githubusercontent.com/assets/959137/10127684/c36fc6a4-65d8-11e5-8b5f-b4e2319800a9.png)


BUT, It's not perfect.
NOT SUPPORT:
1.  the yotta module's include dir name is different with the module name;
2.  module has manual CMakeLists.
