### PR TITLE
prohibit reserved names in schemas, and provide helpful error messages in 'yt init'

### DIFF
--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -131,7 +131,8 @@
                 "type": "string",
              "pattern": "^[a-z]+[a-z0-9-]*$",
            "minLength": 2,
-           "maxLength": 64
+           "maxLength": 64,
+                 "not":{"enum":["test", "source", "yotta_modules", "yotta_targets", "include"]}
         },
         "person": {
                  "type": "string",

--- a/yotta/lib/schema/target.json
+++ b/yotta/lib/schema/target.json
@@ -122,7 +122,8 @@
                 "type": "string",
              "pattern": "^[a-z]+[a-z0-9-]*$",
            "minLength": 2,
-           "maxLength": 64
+           "maxLength": 64,
+                 "not":{"enum":["test", "source", "yotta_modules", "yotta_targets", "include"]}
         },
         "person": {
                  "type": "string",


### PR DESCRIPTION
fixes #105