### PR TITLE
Also name the branch for tip when unpacking

### DIFF
--- a/yotta/lib/git_access.py
+++ b/yotta/lib/git_access.py
@@ -29,10 +29,7 @@ class GitCloneVersion(version.Version):
 
     def unpackInto(self, directory):
         logger.debug('unpack version %s from git repo %s to %s' % (self.version, self.working_copy.directory, directory))
-        if self.isTip():
-            tag = None
-        else:
-            tag = self.tag
+        tag = self.tag
         fsutils.rmRf(directory)
         vcs.Git.cloneToDirectory(self.working_copy.directory, directory, tag)
 


### PR DESCRIPTION
When getting a module from a git repo, you end up with a random branch
checkout, if the branch name is not propagated to Git.cloneToDirectory()