### PR TITLE
Update gcc-arm-none-eabi versions for Ubuntu 14.x-specific instructions.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -180,13 +180,13 @@ sudo apt-get update
 Install the compiler package for Ubuntu 14.04:
 
 ```sh
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q2-1trusty1
+sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q3-1trusty1
 ```
 
 or for Ubuntu 14.10:
 
 ```sh
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q2-0utopic1
+sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q2-1utopic1
 ```
 
 To use this compiler, you'll need to select a supported cross-compilation


### PR DESCRIPTION
Fixed issues with the special arm-gcc installation instructions for Ubuntu 14.x.  The versions that are referenced are not available (not sure if they are just old or maybe incorrect due to typos) and the commands did not work for me.  I updated the references to the versions found at https://launchpad.net/~terry.guo/+archive/ubuntu/gcc-arm-embedded.  These work.  (Actually, I tested the one for 14.04 and it works, but I just visually checked the one for 14.10).