### PR TITLE
Add support for generating dot output from yotta

### DIFF
--- a/yotta/list.py
+++ b/yotta/list.py
@@ -188,7 +188,14 @@ class ComponentDepsFormatter(object):
         if self.dot:
             n = component.getName()
             ni = n.replace('-','_')
-            line = '    {id}[label="{name} {version}"]'.format(id=ni, name=n, version=str(component.getVersion()))
+            colour = 'black'
+            if component.installedLinked():
+                colour = 'forestgreen'
+            line = '    {id}[label="{name} {version}",color={colour},fontcolor={colour}]'.format(
+                            id = ni,
+                          name = n,
+                       version = str(component.getVersion()),
+                        colour = colour)
         else:
             line = indent[:-2] + tee + component.getName() + u' ' + DIM + str(component.getVersion()) + RESET
 


### PR DESCRIPTION
This modifies ```yotta list``` to add support for generating Graphviz dot output.  The output is just dumped to stdout, where it can be processed by the dot tool, or redirected to a file.

While I did highlight test dependencies in blue, missing dependencies in red, I did not see support in ```yotta list``` for identifying testDependencies and their selection criteria.