### PR TITLE
use requests[security] as dependency so that requests works securely on older python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     test_suite = 'yotta.test',
     install_requires=[
         'semantic_version>=2.3.1,<3',
-        'requests>=2.4.3,<3',
+        'requests[security]>=2.4.3,<3',
         'PyGithub>=1.25,<2',
         'colorama>=0.3,<0.4',
         'hgapi>=1.7,<2',


### PR DESCRIPTION
(using python < 2.7.9 is still not recommended though)