### PR TITLE
Updated URLs and schemes

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -8,7 +8,7 @@
     <meta name="author" content="">
 
     <link href='https://fonts.googleapis.com/css?family=Lato:100,400' rel='stylesheet' type='text/css'>
-    <link href="//yottabuild.org/style/css/style.css" rel="stylesheet" type="text/css">
+    <link href="//yotta.mbed.com/style/css/style.css" rel="stylesheet" type="text/css">
     <link href="{{ site.github.url }}/bower_components/bootstrap/dist/css/bootstrap.css" rel="stylesheet">
     <link href="{{ site.github.url }}/assets/css/docs.css" rel="stylesheet">
     <!--[if lt IE 9]>

--- a/docs/bower.json
+++ b/docs/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "yotta-docs",
   "version": "0.0.0",
-  "homepage": "http://docs.yottabuild.org",
+  "homepage": "http://yottadocs.mbed.com",
   "authors": [
     "Andy Pritchard <andy.pritchard@arm.com>"
   ],

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -212,7 +212,7 @@ yotta install <module>
 Which installs `<module>` and its dependencies, and saves it in the current module's description file.
 
 A `<module>` is one of:
- * a name, in which case the module is installed from the public registry (<yottabuild.org>)
+ * a name, in which case the module is installed from the public registry (<https://yotta.mbed.com>)
  * a github spec (username/reponame), in which case the module is installed directly from github. This can include private github URLs.
 
 ##### yotta install (no arguments, in a module folder)
@@ -332,7 +332,7 @@ yotta publish
 ```
 
 #### Description
-Publish the current module or target to the public [`yotta` registry](https://yottabuild.org), where other people will be able to search for and install it.
+Publish the current module or target to the public [`yotta` registry](https://yotta.mbed.com), where other people will be able to search for and install it.
 
 Any files matching lines in the `.yotta_ignore` file (if present) are ignored,
 and will not be included in the published tarball.

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -11,7 +11,7 @@ We’ll look at creating and publishing a module, then using that module in a si
 
 <a name="Creating a Module"></a>
 ## Creating a Module
-Before creating a module you should always check the [yotta registry](http://yottabuild.org) to see if another module already exists that does the same thing. If it does, think about submitting a pull-request to that module first.
+Before creating a module you should always check the [yotta registry](https://yottabuild.org) to see if another module already exists that does the same thing. If it does, think about submitting a pull-request to that module first.
 
 Let’s create a module that provides a really simple logging framework:
 

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -11,7 +11,7 @@ We’ll look at creating and publishing a module, then using that module in a si
 
 <a name="Creating a Module"></a>
 ## Creating a Module
-Before creating a module you should always check the [yotta registry](https://yottabuild.org) to see if another module already exists that does the same thing. If it does, think about submitting a pull-request to that module first.
+Before creating a module you should always check the [yotta registry](https://yotta.mbed.com) to see if another module already exists that does the same thing. If it does, think about submitting a pull-request to that module first.
 
 Let’s create a module that provides a really simple logging framework:
 

--- a/get_yotta.py
+++ b/get_yotta.py
@@ -60,21 +60,21 @@ def shouldInstall(binName):
 # Cygwin Install Script - TODO
 #
 def cygwin():
-	print("Cygwin is not currently supported. Please install for the windows command line. See  http://docs.yottabuild.org/#installing-on-windows for details.");
+	print("Cygwin is not currently supported. Please install for the windows command line. See  http://yottadocs.mbed.com/#installing-on-windows for details.");
 	return;
 
 #
 # Linux Install Script - TODO
 #
 def linux():
-	print("For Linux install instructions please see http://docs.yottabuild.org/#installing-on-linux");
+	print("For Linux install instructions please see http://yottadocs.mbed.com/#installing-on-linux");
 	return;
 
 #
 # OSX Install Script - TODO
 #
 def osx():
-	print("For OSX install instructions please see http://docs.yottabuild.org/#installing-on-osx");
+	print("For OSX install instructions please see http://yottadocs.mbed.com/#installing-on-osx");
 	return;
 
 #

--- a/readme.md
+++ b/readme.md
@@ -19,18 +19,18 @@ pip install yotta
 
 **Note that yotta needs several non-python dependencies to be installed
 correctly in order to do anything useful.** Please follow the **[detailed
-installation instructions](http://docs.yottabuild.org/#installing)** on the
+installation instructions](http://yottadocs.mbed.com/#installing)** on the
 yotta docs website to ensure you have a working installation.
 
 Exactly which other dependencies (such as compilers and other build tools) are
 required will also depend on the [yotta target
-description](http://docs.yottabuild.org/tutorial/targets.html) that you intend
+description](http://yottadocs.mbed.com/tutorial/targets.html) that you intend
 to use, so please be sure to also check the target description's own
 documentation.
 
 ### Get Started!
 The best way to get started is to [follow the
-tutorial](http://docs.yottabuild.org/tutorial/tutorial.html).
+tutorial](http://yottadocs.mbed.com/tutorial/tutorial.html).
 
 ### What `yotta` does
 yotta downloads the software components that your program depends on. It's
@@ -44,10 +44,10 @@ you don't already have installed. It will also update your module's description
 file to reflect the new dependency.
 
 The best way to really understand how yotta works is to [follow the
-tutorial](http://docs.yottabuild.org/tutorial/tutorial.html).
+tutorial](http://yottadocs.mbed.com/tutorial/tutorial.html).
 
 ### Further Documentation
-For further documentation see the [yotta docs](http://docs.yottabuild.org)
+For further documentation see the [yotta docs](http://yottadocs.mbed.com)
 website.
 
 ### Tips

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -44,7 +44,7 @@ import auth
 import yotta.lib.globalconf as globalconf
 
 Registry_Base_URL = 'https://registry.yottabuild.org'
-Website_Base_URL  = 'https://yottabuild.org'
+Website_Base_URL  = 'https://yotta.mbed.com'
 _OpenSSH_Keyfile_Strip = re.compile(b"^(ssh-[a-z0-9]*\s+)|(\s+.+\@.+)|\n", re.MULTILINE)
 
 logger = logging.getLogger('access')

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -44,7 +44,7 @@ import auth
 import yotta.lib.globalconf as globalconf
 
 Registry_Base_URL = 'https://registry.yottabuild.org'
-Website_Base_URL  = 'http://yottabuild.org'
+Website_Base_URL  = 'https://yottabuild.org'
 _OpenSSH_Keyfile_Strip = re.compile(b"^(ssh-[a-z0-9]*\s+)|(\s+.+\@.+)|\n", re.MULTILINE)
 
 logger = logging.getLogger('access')

--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -311,7 +311,7 @@ class DerivedTarget(Target):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 if cmd[0] == 'cmake':
-                    return 'CMake is not installed, please follow the installation instructions at http://docs.yottabuild.org/#installing'
+                    return 'CMake is not installed, please follow the installation instructions at http://yottadocs.mbed.com/#installing'
                 else:
                     return '%s is not installed' % (cmd[0])
             else:

--- a/yotta/lib/vcs.py
+++ b/yotta/lib/vcs.py
@@ -125,7 +125,7 @@ class Git(VCS):
                 if e.errno == errno.ENOENT:
                     if cmd[0] == 'git':
                         raise VCSError(
-                            'git is not installed, or not in your path. Please follow the installation instructions at http://docs.yottabuild.org/#installing'
+                            'git is not installed, or not in your path. Please follow the installation instructions at http://yottadocs.mbed.com/#installing'
                         )
                     else:
                         raise VCSError('%s is not installed' % (cmd[0]))

--- a/yotta/test/cli/account.py
+++ b/yotta/test/cli/account.py
@@ -52,7 +52,7 @@ def loggedin(fn):
         # first load the login URL, so the registry knows about this
         # authentication flow:
         registry_response = session.get(
-            'https://yottabuild.org/#login/' + login_url_data
+            'https://yotta.mbed.com/#login/' + login_url_data
         )
         assert(registry_response.status_code == 200)
         # now get the mbed login URL:

--- a/yotta/test/cli/account.py
+++ b/yotta/test/cli/account.py
@@ -52,7 +52,7 @@ def loggedin(fn):
         # first load the login URL, so the registry knows about this
         # authentication flow:
         registry_response = session.get(
-            'http://yottabuild.org/#login/' + login_url_data
+            'https://yottabuild.org/#login/' + login_url_data
         )
         assert(registry_response.status_code == 200)
         # now get the mbed login URL:


### PR DESCRIPTION
Updated yottabuild.org URLs to point at https://yotta.mbed.com.

Updated docs.yottabuild.org URLs to point at yottadocs.mbed.com

Test URLs and email addresses have been left as is.