### PR TITLE
Search formatting

### DIFF
--- a/yotta/search.py
+++ b/yotta/search.py
@@ -55,7 +55,7 @@ def formatResult(result, plain=False, short=False, indent=''):
         YELLOW = colorama.Fore.YELLOW     #pylint: disable=no-member
         RESET  = colorama.Style.RESET_ALL #pylint: disable=no-member
     else:
-        DIM = BRIGHT = GREEN = RED = RESET = u''
+        DIM = BRIGHT = NORMAL = GREEN = BLUE = RED = YELLOW = RESET = u''
 
     def formatKeyword(keyword):
         if keyword.endswith('official'):

--- a/yotta/search.py
+++ b/yotta/search.py
@@ -5,13 +5,12 @@
 
 # standard library modules, , ,
 from __future__ import print_function
+import itertools
 
 # Registry Access, , access packages in the registry, internal
 from .lib import registry_access
 from .lib import settings
-
-# colorama, BSD 3-Clause license, cross-platform terminal colours, pip install colorama
-import colorama
+from .lib import version
 
 def addOptions(parser):
     parser.add_argument(
@@ -33,43 +32,94 @@ def addOptions(parser):
         '-l', '--limit', default=10, type=int,
         help='Limit the number of results returned.'
     )
+    parser.add_argument(
+        '-s', '--short', default=False, action='store_true',
+        help='Use short output format.'
+    )
 
 def lengthLimit(s, l):
     if len(s) > l:
         return s[:l-3] + '...'
     return s
 
-def execCommand(args, following_args):
-    success = False
-    if not args.plain:
+def formatResult(result, plain=False, short=False, indent=''):
+    if not plain:
+        # colorama, BSD 3-Clause license, cross-platform terminal colours, pip install colorama
+        import colorama
         DIM    = colorama.Style.DIM       #pylint: disable=no-member
         BRIGHT = colorama.Style.BRIGHT    #pylint: disable=no-member
+        NORMAL = colorama.Style.NORMAL    #pylint: disable=no-member
         GREEN  = colorama.Fore.GREEN      #pylint: disable=no-member
         BLUE   = colorama.Fore.BLUE       #pylint: disable=no-member
+        RED    = colorama.Fore.RED        #pylint: disable=no-member
+        YELLOW = colorama.Fore.YELLOW     #pylint: disable=no-member
         RESET  = colorama.Style.RESET_ALL #pylint: disable=no-member
     else:
         DIM = BRIGHT = GREEN = RED = RESET = u''
-    count = 0
-    for result in registry_access.search(query=args.query, keywords=args.kw, registry=args.registry):
-        count += 1
+
+    def formatKeyword(keyword):
+        if keyword.endswith('official'):
+            return BRIGHT + GREEN + keyword + RESET
+        else:
+            return BRIGHT + keyword + NORMAL
+
+    # --short:
+    # module-name module-version: description description
+
+    # not --short:
+    # module-name module-version
+    #    description description description
+    #    keyword, keyword, keyword
+    #    author, author
+
+    v = version.Version(result['version'])
+    if v.major() < 1:
+        if v.minor() < 1:
+            ver_string = RED + result['version'] + RESET
+        else:
+            ver_string = YELLOW + result['version'] + RESET
+    else:
+        ver_string = GREEN + result['version'] + RESET
+
+    name_string = BRIGHT+result['name']+NORMAL
+
+    if 'description' in result:
+        description = result['description']
+        description_colour = ''
+    else:
+        description = '<description missing>'
+        description_colour = RED
+
+    if short:
+        description = description_colour + lengthLimit(description, 160).replace('\n', ' ') + RESET
+    else:
+        description = description_colour + lengthLimit(description, 800).replace('\n', indent+' ').rstrip('\n') + RESET
+
+    if short:
+        return indent+u'%s %s: %s%s' % (name_string, ver_string, description, RESET)
+    else:
+        r = indent+(u'%s %s\n' % (name_string, ver_string)) +\
+            indent+(u'    %s\n' % (description))
+        if 'keywords' in result and result['keywords']:
+            r += indent+(u'    %s\n' % (', '.join([formatKeyword(k) for k in result['keywords']])))
+        if 'author' in result and result['author']:
+            r += indent+(u'    %s\n' % (DIM + result['author'] + RESET))
+        return r.rstrip('\n')
+
+def execCommand(args, following_args):
+    success = False
+    for result in itertools.islice(registry_access.search(query=args.query, keywords=args.kw, registry=args.registry), args.limit):
         success= True
-        if count > args.limit:
-            break
         if args.type == 'both' or args.type == result['type']:
-            description = result['description'] if 'description' in result else '<no description>'
-            print('%s%s %s%s%s: %s' % (GREEN, result['name'], RESET+DIM, result['version'], RESET, lengthLimit(description, 160)))
+            print(formatResult(result, args.plain, short=args.short))
     for repo in filter(lambda s: 'type' in s and s['type'] == 'registry', settings.get('sources') or []) :
         count = 0
         print('')
         print('additional results from %s:' % repo['url'])
-        for result in registry_access.search(query=args.query, keywords=args.kw, registry=repo['url']):
-            count += 1
+        for result in itertools.islice(registry_access.search(query=args.query, keywords=args.kw, registry=repo['url']), args.limit):
             success= True
-            if count > args.limit:
-                break
             if args.type == 'both' or args.type == result['type']:
-                description = result['description'] if 'description' in result else '<no description>'
-                print('  %s%s %s%s%s: %s' % (GREEN, result['name'], RESET+DIM, result['version'], RESET, lengthLimit(description, 160)))
+                print(formatResult(result, args.plain, indent='  ', short=args.short))
     # exit status: success if we found something, otherwise fail
     return 0 if success else 1
 

--- a/yotta/search.py
+++ b/yotta/search.py
@@ -63,6 +63,12 @@ def formatResult(result, plain=False, short=False, indent=''):
         else:
             return BRIGHT + keyword + NORMAL
 
+    def formatAuthor(author):
+        if isinstance(author, dict):
+            return author.get('name', '<name unknown>') + ' ' + author.get('email', '<email unknown')
+        else:
+            return author
+
     # --short:
     # module-name module-version: description description
 
@@ -102,8 +108,16 @@ def formatResult(result, plain=False, short=False, indent=''):
             indent+(u'    %s\n' % (description))
         if 'keywords' in result and result['keywords']:
             r += indent+(u'    %s\n' % (', '.join([formatKeyword(k) for k in result['keywords']])))
+
         if 'author' in result and result['author']:
-            r += indent+(u'    %s\n' % (DIM + result['author'] + RESET))
+            authors = [result['author']]
+        elif 'maintainers' in result and len(result['maintainers']):
+            authors = result['maintainers']
+        else:
+            authors = []
+        if len(authors):
+            r += indent+(u'    %s\n' % (DIM + (', '.join([formatAuthor(a) for a in authors])) + RESET))
+
         return r.rstrip('\n')
 
 def execCommand(args, following_args):

--- a/yotta/test/cli/search.py
+++ b/yotta/test/cli/search.py
@@ -13,32 +13,40 @@ from . import cli
 
 class TestCLISearch(unittest.TestCase):
     def test_bothModule(self):
-        stdout = self.runCheckCommand(['search', 'polyfill'])
+        stdout = self.runCheckCommand(['search', 'polyfill', '--short'])
         self.assertTrue(stdout.find('compiler-polyfill') != -1)
 
     def test_bothTarget(self):
-        stdout = self.runCheckCommand(['search', 'frdm-k64f'])
+        stdout = self.runCheckCommand(['search', 'frdm-k64f', '--short'])
         self.assertTrue(stdout.find('frdm-k64f-gcc') != -1)
 
     def test_both(self):
-        stdout = self.runCheckCommand(['search', 'both', 'polyfill'])
+        stdout = self.runCheckCommand(['--plain', 'search', 'both', 'polyfill', '--short'])
         self.assertTrue(stdout.find('compiler-polyfill') != -1)
 
     def test_modules(self):
-        stdout = self.runCheckCommand(['search', 'module', 'polyfill'])
+        stdout = self.runCheckCommand(['search', 'module', 'polyfill', '--short'])
         self.assertTrue(stdout.find('compiler-polyfill') != -1)
 
     def test_targets(self):
-        stdout = self.runCheckCommand(['search', 'target', 'frdm-k64f'])
+        stdout = self.runCheckCommand(['search', 'target', 'frdm-k64f', '--short'])
         self.assertTrue(stdout.find('frdm-k64f-gcc') != -1)
 
     def test_keywords(self):
-        stdout = self.runCheckCommand(['search', 'module', 'polyfill', '-k', 'polyfill'])
+        stdout = self.runCheckCommand(['search', 'module', 'polyfill', '-k', 'polyfill', '--short'])
         self.assertTrue(stdout.find('compiler-polyfill') != -1)
 
     def test_limit(self):
         stdout = self.runCheckCommand(['search', 'module', 'compiler-polyfill', '-l', '5', '-k', 'polyfill'])
         self.assertTrue(stdout.find('compiler-polyfill') != -1)
+
+    def test_author(self):
+        stdout = self.runCheckCommand(['search', 'module', 'compiler-polyfill', '-l', '1', '-k', 'polyfill'])
+        self.assertTrue(stdout.find('james.crosby@arm.com') != -1)
+
+    def test_keywords(self):
+        stdout = self.runCheckCommand(['search', 'module', 'compiler-polyfill', '-l', '1', '-k', 'polyfill'])
+        self.assertTrue(stdout.find('mbed-official') != -1)
 
     def runCheckCommand(self, args):
         stdout, stderr, statuscode = cli.run(args)

--- a/yotta/test/cli/search.py
+++ b/yotta/test/cli/search.py
@@ -44,7 +44,7 @@ class TestCLISearch(unittest.TestCase):
         stdout = self.runCheckCommand(['search', 'module', 'compiler-polyfill', '-l', '1', '-k', 'polyfill'])
         self.assertTrue(stdout.find('james.crosby@arm.com') != -1)
 
-    def test_keywords(self):
+    def test_keyword_display(self):
         stdout = self.runCheckCommand(['search', 'module', 'compiler-polyfill', '-l', '1', '-k', 'polyfill'])
         self.assertTrue(stdout.find('mbed-official') != -1)
 


### PR DESCRIPTION
Resolves #483 and #472 

examples:

dark terminal:
<img width="661" alt="screen shot 2015-10-20 at 12 30 23" src="https://cloud.githubusercontent.com/assets/3456211/10605817/5cade590-7726-11e5-9f1a-b29257752dbd.png">

light terminal:
<img width="486" alt="screen shot 2015-10-20 at 12 30 42" src="https://cloud.githubusercontent.com/assets/3456211/10605830/6b9b0d44-7726-11e5-82df-4932d6e91cd3.png">


