### PR TITLE
fix test $program path expansion

### DIFF
--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -569,7 +569,7 @@ class DerivedTarget(Target):
             cmd = shlex.split(test_command)
         else:
             cmd = [
-                os.path.expandvars(string.Template(x).safe_substitute(program=test_command))
+                os.path.expandvars(string.Template(x).safe_substitute(program=os.path.abspath(os.path.join(cwd, test_command))))
                 for x in self.description['scripts']['test']
             ] + forward_args
 


### PR DESCRIPTION
Test execution command string substitution for $program should reference absolute path (or relative to calling cwd) based on python docs- 
https://docs.python.org/2/library/subprocess.html#popen-constructor
>If *cwd* is not None, the child’s current directory will be changed to *cwd* before it is executed. Note that this directory is not considered when searching the executable, so you can’t specify the program’s path relative to *cwd*.

Needed for it to work on Windows.