### PR TITLE
improve github authentication handling decorator:

### DIFF
--- a/yotta/lib/github_access.py
+++ b/yotta/lib/github_access.py
@@ -46,49 +46,62 @@ def _handleAuth(fn):
         # if yotta is being run noninteractively, then we never retry, but we
         # do call auth.authorizeUser, so that a login URL can be displayed:
         interactive = globalconf.get('interactive')
-        if not interactive:
-            try:
-                return fn(*args, **kwargs)
-            except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 401:
-                    auth.authorizeUser(provider='github', interactive=False)
-                raise
-            except github.BadCredentialsException:
-                logger.debug("github: bad credentials")
-                auth.authorizeUser(provider='github', interactive=False)
-                raise
-            except github.UnknownObjectException:
-                logger.debug("github: unknown object")
-                # some endpoints return 404 if the user doesn't have access:
-                if not _userAuthedWithGithub():
-                    logger.info('failed to fetch Github object, try re-authing...')
-                    auth.authorizeUser(provider='github', interactive=False)
-                raise
-        else:
-            try:
-                return fn(*args, **kwargs)
-            except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 401:
-                    auth.authorizeUser(provider='github')
-                    return fn(*args, **kwargs)
-                raise
-            except github.BadCredentialsException:
-                logger.debug("github: bad credentials")
-                auth.authorizeUser(provider='github')
+
+        def retryWithAuthOrRaise():
+            # in all cases ask for auth, so that in non-interactive mode a
+            # login URL is displayed
+            auth.authorizeUser(provider='github', interactive=interactive)
+            if not interactive:
+                import sys
+                exc_class, exc_obj, exc_tb = sys.exc_info()
+                raise exc_class, exc_obj, exc_tb
+            else:
                 logger.debug('trying with authtoken: %s', settings.getProperty('github', 'authtoken'))
                 return fn(*args, **kwargs)
-            except github.UnknownObjectException:
-                logger.debug("github: unknown object")
-                # some endpoints return 404 if the user doesn't have access, maybe
-                # it would be better to prompt for another username and password,
-                # and store multiple tokens that we can try for each request....
-                # but for now we assume that if the user is logged in then a 404
-                # really is a 404
-                if not _userAuthedWithGithub():
-                    logger.info('failed to fetch Github object, re-trying with authentication...')
-                    auth.authorizeUser(provider='github')
-                    return fn(*args, **kwargs)
-                raise
+
+        # authorised requests have a higher rate limit, but display a warning
+        # message in this case, as the user might not expect the requirement to
+        # auth:
+        def handleRateLimitExceeded():
+            if not _userAuthedWithGithub():
+                logger.warning('github rate limit for anonymous requests exceeded: you must log in')
+                return retryWithAuthOrRaise()
+            else:
+                import sys
+                exc_class, exc_obj, exc_tb = sys.exc_info()
+                raise exc_class, exc_obj, exc_tb
+
+        try:
+            return fn(*args, **kwargs)
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 403:
+                # 403 = rate limit exceeded
+                return handleRateLimitExceeded()
+            if e.response.status_code == 401:
+                # 401 = unauthorised
+                return retryWithAuthOrRaise()
+            raise
+        except github.BadCredentialsException:
+            logger.debug("github: bad credentials")
+            return retryWithAuthOrRaise()
+        except github.UnknownObjectException:
+            logger.debug("github: unknown object")
+            # some endpoints return 404 if the user doesn't have access, maybe
+            # it would be better to prompt for another username and password,
+            # and store multiple tokens that we can try for each request....
+            # but for now we assume that if the user is logged in then a 404
+            # really is a 404
+            if not _userAuthedWithGithub():
+                logger.info('failed to fetch Github object, re-trying with authentication...')
+                return retryWithAuthOrRaise()
+            raise
+        except github.RateLimitExceededException as e:
+            return handleRateLimitExceeded()
+        except github.GithubException as e:
+            if e.status == 403:
+                # 403 = rate limit exceeded
+                return handleRateLimitExceeded()
+            raise
     return wrapped
 
 @_handleAuth

--- a/yotta/lib/github_access.py
+++ b/yotta/lib/github_access.py
@@ -47,14 +47,12 @@ def _handleAuth(fn):
         # do call auth.authorizeUser, so that a login URL can be displayed:
         interactive = globalconf.get('interactive')
 
-        def retryWithAuthOrRaise():
+        def retryWithAuthOrRaise(original_exception):
             # in all cases ask for auth, so that in non-interactive mode a
             # login URL is displayed
             auth.authorizeUser(provider='github', interactive=interactive)
             if not interactive:
-                import sys
-                exc_class, exc_obj, exc_tb = sys.exc_info()
-                raise exc_class, exc_obj, exc_tb
+                raise original_exception
             else:
                 logger.debug('trying with authtoken: %s', settings.getProperty('github', 'authtoken'))
                 return fn(*args, **kwargs)
@@ -62,29 +60,27 @@ def _handleAuth(fn):
         # authorised requests have a higher rate limit, but display a warning
         # message in this case, as the user might not expect the requirement to
         # auth:
-        def handleRateLimitExceeded():
+        def handleRateLimitExceeded(original_exception):
             if not _userAuthedWithGithub():
                 logger.warning('github rate limit for anonymous requests exceeded: you must log in')
-                return retryWithAuthOrRaise()
+                return retryWithAuthOrRaise(original_exception)
             else:
-                import sys
-                exc_class, exc_obj, exc_tb = sys.exc_info()
-                raise exc_class, exc_obj, exc_tb
+                raise original_exception
 
         try:
             return fn(*args, **kwargs)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 403:
                 # 403 = rate limit exceeded
-                return handleRateLimitExceeded()
+                return handleRateLimitExceeded(e)
             if e.response.status_code == 401:
                 # 401 = unauthorised
-                return retryWithAuthOrRaise()
+                return retryWithAuthOrRaise(e)
             raise
-        except github.BadCredentialsException:
+        except github.BadCredentialsException as e:
             logger.debug("github: bad credentials")
-            return retryWithAuthOrRaise()
-        except github.UnknownObjectException:
+            return retryWithAuthOrRaise(e)
+        except github.UnknownObjectException as e:
             logger.debug("github: unknown object")
             # some endpoints return 404 if the user doesn't have access, maybe
             # it would be better to prompt for another username and password,
@@ -93,14 +89,14 @@ def _handleAuth(fn):
             # really is a 404
             if not _userAuthedWithGithub():
                 logger.info('failed to fetch Github object, re-trying with authentication...')
-                return retryWithAuthOrRaise()
+                return retryWithAuthOrRaise(e)
             raise
         except github.RateLimitExceededException as e:
-            return handleRateLimitExceeded()
+            return handleRateLimitExceeded(e)
         except github.GithubException as e:
             if e.status == 403:
                 # 403 = rate limit exceeded
-                return handleRateLimitExceeded()
+                return handleRateLimitExceeded(e)
             raise
     return wrapped
 


### PR DESCRIPTION
( treat rate-limit-exceeded errors as requiring auth, and reduce code duplication)

Fixes #539 

cc @thegecko 