### PR TITLE
Resolve linked paths at creation-time. (fix #571)

### DIFF
--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -117,7 +117,8 @@ class Pack(object):
             schema_filename = None,
             latest_suitable_version = None
         ):
-        self.path = path
+        # resolve links at creation time, to minimise path lengths:
+        self.path = fsutils.realpath(path)
         self.installed_linked = installed_linked
         self.vcs = None
         self.error = None


### PR DESCRIPTION
When creating a component/target object immediately resolve any symlink in the
path. This prevents symlinks propagating through to the build, where they can
cause exceptionally long paths (causing problems on windows).

This should also fix #157.