### PR TITLE
Record where modules came from.

### DIFF
--- a/yotta/lib/access_common.py
+++ b/yotta/lib/access_common.py
@@ -178,7 +178,7 @@ def unpackFromCache(cache_key, to_directory):
     try:
         unpackFrom(path, to_directory)
         if os.path.exists(path + '.json'):
-            shutil.copy(path + '.json', os.path.join(to_directory, '.module-origin.json'))
+            shutil.copy(path + '.json', os.path.join(to_directory, '.yotta_origin.json'))
         cache_logger.debug('unpacked %s from cache into %s', cache_key, to_directory)
         return
     except IOError as e:

--- a/yotta/lib/access_common.py
+++ b/yotta/lib/access_common.py
@@ -20,6 +20,8 @@ import version
 import fsutils
 # folders, , where yotta stores things, internal
 import folders
+# Ordered JSON, , read & write json, internal
+import ordered_json
 
 logger = logging.getLogger('access')
 cache_logger = logging.getLogger('cache')
@@ -90,11 +92,13 @@ def pruneCache():
     # ensure cache exists
     fsutils.mkDirP(cache_dir)
     for f in sorted(
-            [f for f in os.listdir(cache_dir) if os.path.isfile(fullpath(f))],
+            [f for f in os.listdir(cache_dir) if
+                os.path.isfile(fullpath(f)) and not f.endswith('.json')
+            ],
             key = lambda f: os.stat(fullpath(f)).st_mtime
         )[Max_Cached_Modules:]:
         cache_logger.debug('cleaning up cache file %s', f)
-        fsutils.rmF(fullpath(f))
+        removeFromCache(f)
     cache_logger.debug('cache pruned to %s items', Max_Cached_Modules)
 
 def sometimesPruneCache(p):
@@ -155,6 +159,12 @@ def unpackFrom(tar_file_path, to_directory):
             # if anything has failed, cleanup
             fsutils.rmRf(temp_directory)
 
+def removeFromCache(cache_key):
+    f = os.path.join(folders.cacheDirectory(), cache_key)
+    fsutils.rmF(f)
+    # remove any metadata too, if it exists
+    fsutils.rmF(f + '.json')
+
 def unpackFromCache(cache_key, to_directory):
     ''' If the specified cache key exists, unpack the tarball into the
         specified directory, otherwise raise KeyError.
@@ -167,6 +177,8 @@ def unpackFromCache(cache_key, to_directory):
     logger.debug('attempt to unpack from cache %s -> %s', path, to_directory)
     try:
         unpackFrom(path, to_directory)
+        if os.path.exists(path + '.json'):
+            shutil.copy(path + '.json', os.path.join(to_directory, '.module-origin.json'))
         cache_logger.debug('unpacked %s from cache into %s', cache_key, to_directory)
         return
     except IOError as e:
@@ -174,12 +186,11 @@ def unpackFromCache(cache_key, to_directory):
             cache_logger.debug('%s not in cache', cache_key)
             raise KeyError('not in cache')
 
-def downloadToCache(stream, hashinfo={}, cache_key=None):
+def downloadToCache(stream, hashinfo={}, cache_key=None, origin_info=dict()):
     ''' Download the specified stream to a temporary cache directory, and
-        return (path to the downloaded, cache key).
-        If cache_key is None, then a cache key will be generated and returned,
-        but you will probably want to remove the cache file yourself (this is
-        safe).
+        returns a cache key that can be used to access/remove the file.
+        If cache_key is None, then a cache key will be generated and returned.
+        You will probably want to use removeFromCache(cache_key) to remove it.
     '''
     hash_name  = None
     hash_value = None
@@ -204,8 +215,9 @@ def downloadToCache(stream, hashinfo={}, cache_key=None):
     cache_dir = folders.cacheDirectory()
     fsutils.mkDirP(cache_dir)
     cache_as = os.path.join(cache_dir, cache_key)
+    file_size = 0
 
-    (download_file, download_fname) = tempfile.mkstemp(prefix=cache_dir)
+    (download_file, download_fname) = tempfile.mkstemp(dir=cache_dir)
     with os.fdopen(download_file, 'wb') as f:
         f.seek(0)
         for chunk in stream.iter_content(4096):
@@ -222,10 +234,17 @@ def downloadToCache(stream, hashinfo={}, cache_key=None):
             )
             if hash_value and (hash_value != calculated_hash):
                 raise Exception('Hash verification failed.')
-        logger.debug('wrote tarfile of size: %s to %s', f.tell(), download_fname)
+        file_size = f.tell()
+        logger.debug('wrote tarfile of size: %s to %s', file_size, download_fname)
         f.truncate()
     try:
         os.rename(download_fname, cache_as)
+        extended_origin_info = {
+            'hash': hashinfo,
+            'size': file_size
+        }
+        extended_origin_info.update(origin_info)
+        ordered_json.dump(cache_as + '.json', extended_origin_info)
     except OSError as e:
         if e.errno == errno.ENOENT:
             # if we failed, it's because the file already exists (probably
@@ -236,21 +255,21 @@ def downloadToCache(stream, hashinfo={}, cache_key=None):
         else:
             raise
 
-    return (cache_as, cache_key)
+    return cache_key
 
 @sometimesPruneCache(0.05)
-def unpackTarballStream(stream, into_directory, hash={}, cache_key=None):
+def unpackTarballStream(stream, into_directory, hash={}, cache_key=None, origin_info=dict()):
     ''' Unpack a responses stream that contains a tarball into a directory. If
         a hash is provided, then it will be used as a cache key (for future
         requests you can try to retrieve the key value from the cache first,
         before making the request)
     '''
 
-    download_fname, cache_key = downloadToCache(stream, hash, cache_key)
-    unpackFromCache(cache_key, into_directory)
+    new_cache_key = downloadToCache(stream, hash, cache_key, origin_info)
+    unpackFromCache(new_cache_key, into_directory)
 
     # if we didn't provide a cache key, there's no point in storing the cache
     if cache_key is None:
-        fsutils.rmF(download_fname)
+        removeFromCache(new_cache_key)
 
 

--- a/yotta/lib/github_access.py
+++ b/yotta/lib/github_access.py
@@ -134,7 +134,7 @@ def _getTipArchiveURL(repo):
 
 
 @_handleAuth
-def _getTarball(url, into_directory, cache_key):
+def _getTarball(url, into_directory, cache_key, origin_info=None):
     '''unpack the specified tarball url into the specified directory'''
 
     try:
@@ -159,7 +159,8 @@ def _getTarball(url, into_directory, cache_key):
                     stream = response,
             into_directory = into_directory,
                       hash = {},
-                 cache_key = cache_key
+                 cache_key = cache_key,
+               origin_info = origin_info
         )
 
 
@@ -181,13 +182,18 @@ class GithubComponentVersion(access_common.RemoteVersion):
         self.cache_key = cache_key
         self.tag = tag
         github_spec = re.search('/(repos|codeload.github.com)/([^/]*/[^/]*)/', url).group(2)
+        self.origin_info = {
+            'url':('github://'+github_spec+'#'+(semver or tag))
+        }
         super(GithubComponentVersion, self).__init__(
             semver, url, name=name, friendly_version=(semver or tag), friendly_source=('GitHub %s' % github_spec)
         )
 
     def unpackInto(self, directory):
         assert(self.url)
-        _getTarball(self.url, directory, self.cache_key)
+        _getTarball(
+            self.url, directory, self.cache_key, origin_info=self.origin_info
+        )
 
 class GithubComponent(access_common.RemoteComponent):
     def __init__(self, repo, tag_or_branch=None, semantic_spec=None, name=None):

--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -52,6 +52,7 @@ Default_Publish_Ignore = [
 Readme_Regex = re.compile('^readme(?:\.md)', re.IGNORECASE)
 
 Ignore_List_Fname = '.yotta_ignore'
+Origin_Info_Fname = '.yotta_origin.json'
 
 logger = logging.getLogger('components')
 
@@ -118,6 +119,7 @@ class Pack(object):
             latest_suitable_version = None
         ):
         # resolve links at creation time, to minimise path lengths:
+        self.unresolved_path = path
         self.path = fsutils.realpath(path)
         self.installed_linked = installed_linked
         self.vcs = None
@@ -127,6 +129,7 @@ class Pack(object):
         self.description_filename = description_filename
         self.ignore_list_fname = Ignore_List_Fname
         self.ignore_patterns = copy.copy(Default_Publish_Ignore)
+        self.origin_info = None
         description_file = os.path.join(path, description_filename)
         if os.path.isfile(description_file):
             try:
@@ -171,6 +174,17 @@ class Pack(object):
             #if have_errors:
             #    raise InvalidDescription('Invalid %s' % description_filename)
         self.vcs = vcs.getVCS(path)
+
+    def origin(self):
+        ''' Read the .yotta_origin.json file (if present), and return the value
+            of the 'url' property '''
+        if self.origin_info is None:
+            self.origin_info = {}
+            try:
+                self.origin_info = ordered_json.load(os.path.join(self.path, Origin_Info_Fname))
+            except IOError:
+                pass
+        return self.origin_info.get('url', None)
 
     def getRegistryNamespace(self):
         raise NotImplementedError("must be implemented by subclass")

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -305,9 +305,12 @@ def _getSources():
 def _isPublicRegistry(registry):
     return (registry is None) or (registry == Registry_Base_URL)
 
-def _friendlyRegistryName(registry):
-    if registry == Registry_Base_URL:
-        return 'the public module registry'
+def friendlyRegistryName(registry, short=False):
+    if registry.startswith(Registry_Base_URL):
+        if short:
+            return 'public registry'
+        else:
+            return 'the public module registry'
     else:
         return registry
 
@@ -436,7 +439,7 @@ class RegistryThingVersion(access_common.RemoteVersion):
             self.sha256 = None
         url = _tarballURL(self.namespace, self.name, version, registry)
         super(RegistryThingVersion, self).__init__(
-            version, url, name=name, friendly_source=_friendlyRegistryName(registry)
+            version, url, name=name, friendly_source=friendlyRegistryName(registry)
         )
 
     def unpackInto(self, directory):

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -292,7 +292,8 @@ def _getTarball(url, directory, sha256):
                     stream = response,
             into_directory = directory,
                       hash = {'sha256':sha256},
-                 cache_key = sha256
+                 cache_key = sha256,
+               origin_info = {'url':url}
         )
 
 def _getSources():


### PR DESCRIPTION
Write .module-origin.json files in downloaded modules containing the source
they were downloaded from, and information about the downloaded file.

(lays the groundwork necessary to fix #569/#238)