### PR TITLE
Improvements to module/target cache.

### DIFF
--- a/yotta/lib/access_common.py
+++ b/yotta/lib/access_common.py
@@ -89,6 +89,7 @@ def getMaxCachedModules():
         if _max_cached_modules is None:
             # arbitrary default value
             _max_cached_modules = 200
+    return _max_cached_modules
 
 def pruneCache():
     ''' Prune the cache '''

--- a/yotta/lib/access_common.py
+++ b/yotta/lib/access_common.py
@@ -103,8 +103,9 @@ def pruneCache():
             [f for f in os.listdir(cache_dir) if
                 os.path.isfile(fullpath(f)) and not f.endswith('.json')
             ],
-            key = lambda f: os.stat(fullpath(f)).st_mtime
-        )[max_cached_modules]:
+            key = lambda f: os.stat(fullpath(f)).st_mtime,
+            reverse = True
+        )[max_cached_modules:]:
         cache_logger.debug('cleaning up cache file %s', f)
         removeFromCache(f)
     cache_logger.debug('cache pruned to %s items', max_cached_modules)


### PR DESCRIPTION
 * fix race-condition where the item being copied out of the cache might be
   removed in between testing for the existence of the metadata file and
   copying it. (It's better to try than to test...)
 * make the cache size settable in settings file / YOTTA_MAX_CACHED_MOULES env
   var