### PR TITLE
Remind target developers to select their target

### DIFF
--- a/docs/tutorial/targets.md
+++ b/docs/tutorial/targets.md
@@ -210,6 +210,13 @@ cd ../path/to/my/module
 yotta link-target my-target
 ```
 
+You should also select your new target from the module directory before
+attempting to build for it for the first time.
+
+```sh
+yotta target my-target
+```
+
 Now when you build, your new target description will be used. Note that
 currently you need to remove the build directory after editing the target's
 toolchain file, as CMake does not add dependency rules on the toolchain:


### PR DESCRIPTION
It is helpful to point out, especially to people new to yotta, that when
developing new targets, one must also select their newly created target
from the module they are testing their new target with.