### PR TITLE
Improve validation when `yotta link`ing

### DIFF
--- a/yotta/lib/validate.py
+++ b/yotta/lib/validate.py
@@ -49,7 +49,7 @@ def componentNameValidationError(component_name):
 
 def targetNameValidationError(target_name):
     if not re.match(Target_Name_Regex, target_name):
-        return 'Module name "%s" is invalid - must contain only lowercase a-z, 0-9 and hyphen, with no spaces.' % target_name
+        return 'Target name "%s" is invalid - must contain only lowercase a-z, 0-9, + and hyphen, with no spaces.' % target_name
     return None
 
 def componentNameCoerced(component_name):

--- a/yotta/link.py
+++ b/yotta/link.py
@@ -1,4 +1,4 @@
-# Copyright 2014 ARM Limited
+# Copyright 2014-2015 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0
 # See LICENSE file for details.
@@ -29,6 +29,10 @@ def execCommand(args, following_args):
     if not c:
         return 1
     if args.component:
+        err = validate.componentNameValidationError(args.component)
+        if err:
+            logging.error(err)
+            return 1
         fsutils.mkDirP(os.path.join(os.getcwd(), 'yotta_modules'))
         src = os.path.join(folders.globalInstallDirectory(), args.component)
         dst = os.path.join(os.getcwd(), 'yotta_modules', args.component)

--- a/yotta/link_target.py
+++ b/yotta/link_target.py
@@ -1,4 +1,4 @@
-# Copyright 2014 ARM Limited
+# Copyright 2014-2015 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0
 # See LICENSE file for details.
@@ -10,10 +10,10 @@ import os
 # colorama, BSD 3-Clause license, color terminal output, pip install colorama
 import colorama
 
-# Target, , represents an installed target, internal
-from .lib import target
 # fsutils, , misc filesystem utils, internal
 from .lib import fsutils
+# validate, , validate things, internal
+from .lib import validate
 # folders, , get places to install things, internal
 from .lib import folders
 
@@ -26,20 +26,25 @@ def addOptions(parser):
 
 def execCommand(args, following_args):
     if args.target:
+        c = validate.currentDirectoryModule()
+        if not c:
+            return 1
+        err = validate.targetNameValidationError(args.target)
+        if err:
+            logging.error(err)
+            return 1
         fsutils.mkDirP(os.path.join(os.getcwd(), 'yotta_targets'))
         src = os.path.join(folders.globalTargetInstallDirectory(), args.target)
         dst = os.path.join(os.getcwd(), 'yotta_targets', args.target)
         # if the target is already installed, rm it
         fsutils.rmRf(dst)
     else:
-        c = target.Target(os.getcwd())
-        if not c:
-            logging.debug(str(c.error))
-            logging.error('The current directory does not contain a valid target.')
+        t = validate.currentDirectoryTarget()
+        if not t:
             return 1
         fsutils.mkDirP(folders.globalTargetInstallDirectory())
         src = os.getcwd()
-        dst = os.path.join(folders.globalTargetInstallDirectory(), c.getName())
+        dst = os.path.join(folders.globalTargetInstallDirectory(), t.getName())
 
     if args.target:
         realsrc = fsutils.realpath(src)


### PR DESCRIPTION
 * validate the module/target name, preventing full paths from being passed
   accidentally.
 * validate that link-target (no arguments) is only used in targets
 * use consistent validation that link-target and link (with argument) are only
   used in modules

cc @adbridge 