### PR TITLE
Add --github flag to login.

### DIFF
--- a/yotta/login.py
+++ b/yotta/login.py
@@ -19,6 +19,16 @@ def addOptions(parser):
     # pass the API key for logging into this registry (it will be saved, and
     # used for future requests to this registry)
     parser.add_argument('--apikey', '-k', dest='apikey', help=argparse.SUPPRESS)
+    # --github can be used to force login with github instead of mbed, the
+    # default): github login is necessary for pulling things from private
+    # github repositories. You shouldn't normally need to do this, as you will
+    # be prompted for github login automatically when required, but this is
+    # useful if you want to pre-cache login information for any reason.
+    parser.add_argument('--github', dest='github_login', action='store_true',
+        default=False, help='force login with GitHub instead of mbed. You '+
+        "shouldn't normally need to use this switch, as you will be prompted "+
+        "for GitHub login automatically if required."
+    )
 
 def execCommand(args, following_args):
     registry = args._registry or args.registry
@@ -26,7 +36,10 @@ def execCommand(args, following_args):
         registry_access.setAPIKey(registry, args.apikey)
 
     try:
-        return auth.authorizeUser(registry, provider=None, interactive=args.interactive)
+        provider = None
+        if args.github_login:
+            provider = 'github'
+        return auth.authorizeUser(registry, provider=provider, interactive=args.interactive)
     except auth.AuthTimedOut as e:
         logging.error("Login failed: %s", e)
         return 1


### PR DESCRIPTION
This makes it possible to login with GitHub before a private repository has
been encountered, for example to pre-cache an authtoken before running a long
series of tests.

Fixes #608