### PR TITLE
Fix JWT encoding irregularities

### DIFF
--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -66,7 +66,7 @@ def generate_jwt_token(private_key, registry=None):
         "iss": 'yotta',
         "aud": registry,
         "prn": prn,
-        "exp": str(expires)
+        "exp": expires
     }
     logger.debug('token fields: %s' % token_fields)
     private_key_pem = private_key.private_bytes(

--- a/yotta/lib/registry_access.py
+++ b/yotta/lib/registry_access.py
@@ -59,7 +59,7 @@ class AuthError(RuntimeError):
 
 def generate_jwt_token(private_key, registry=None):
     registry = registry or Registry_Base_URL
-    expires = calendar.timegm((datetime.datetime.utcnow() + datetime.timedelta(hours=2)).timetuple())
+    expires = calendar.timegm((datetime.datetime.utcnow() + datetime.timedelta(minutes=2)).timetuple())
     prn = _fingerprint(private_key.public_key())
     logger.debug('fingerprint: %s' % prn)
     token_fields = {


### PR DESCRIPTION
 * exp should be a number (the registry incorrectly accepted and decoded a string)
 * tighten up the expiry time to reduce possibility of replay

Fixes #613