### PR TITLE
Better support and document `yotta build -G` for IDE project file generation.

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -62,19 +62,48 @@ Options:
 
  * `--generate-only`, `-g`: only generate the CMakeLists, don't build
  * `--release-build`, `-r`: build a release (optimised) build. The exact effects depend on the toolchain.
- * `--cmake-generator`, `-G`: specify the CMake Generator. CMake can generate project files for various editors and IDEs, though some IDEs may not be able to use non-standard compilers defined by `yotta` targets without additional plugins. The available generators depend on whether `yotta` is running on OS X, Linux, or Windows.
+ * `--cmake-generator`, `-G`: specify the CMake Generator. CMake can generate project files for various editors and IDEs.
  * `name ...`: one or more modules may be specified, in which case only these
    modules and their dependencies will be built. Use `all_tests` to cause all
    tests to be built.
  * `-- ...`: any options specified after `--` are passed unmodified on to the tool being used for building (e.g. Ninja, or make)
 
+#### Generating IDE Project Files
+The `-G`/`--cmake-generator` option can be used to generate project files for
+various IDE and text editors. This option is passed through to CMake, but note
+that only IDE project files which use Ninja or Makefile build systems will
+correctly support cross-compilation for yotta targets.
+
+To see the [CMake generators](https://cmake.org/cmake/help/v3.0/manual/cmake-generators.7.html)
+available on your platform see `cmake --help`.
+
+
 #### Examples
 
-```
+Build this module and its tests:
+
+```sh
 yotta build
+```
+
+Build the tests for all dependencies:
+
+```sh
 yotta build -d all_tests
+```
+
+Generating IDE project files:
+
+```sh
 yotta build -d -G "Sublime Text 2 - Ninja"
+yotta build -d -G "Eclipse CDT4 - Ninja"
+```
+
+Passing options through to the build system:
+
+```sh
 yotta build -G "Unix Makefiles" -- -j 4
+yotta build -- -v
 ```
 
 ## <a href="#yotta-search" name="yotta-search">#</a> yotta search

--- a/docs/tutorial/building.md
+++ b/docs/tutorial/building.md
@@ -75,3 +75,26 @@ natively using the x86-osx-native target:
 [info] Hello yotta!
 ```
 
+## Building with an IDE
+
+Because yotta uses [CMake](https://cmake.org) to describe what to build, it can
+also generate project files for some of the [IDEs that CMake
+can](https://cmake.org/cmake/help/v3.0/manual/cmake-generators.7.html)
+(currently support is limited to generators that use an underlying Makefile or
+Ninja-based build system, as other IDEs do not respect yotta's target
+descriptions).
+
+For example, to build with sublime text project files:
+
+```
+yotta build -G "Sublime Text 2 - Ninja"
+```
+
+(if you get an error that you previously built using a different generator, you
+need to run `yotta clean` first)
+
+Or to build Eclipse CDT project files:
+
+```
+yotta build -G "Eclipse CDT4 - Ninja"
+```

--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -275,22 +275,7 @@ class DerivedTarget(Target):
            'possible generator names. Note that only Ninja or Unix Makefile '+
            'based generators will work correctly with yotta.',
            metavar='CMAKE_GENERATOR',
-           choices=(
-               'Unix Makefiles',
-               'Ninja',
-               'Xcode',
-               'Sublime Text 2 - Ninja',
-               'Sublime Text 2 - Unix Makefiles'
-               'CodeBlocks - Ninja',
-               'CodeBlocks - Unix Makefiles',
-               'CodeLite - Ninja',
-               'CodeLite - Unix Makefiles',
-               'Eclipse CDT4 - Ninja',
-               'Eclipse CDT4 - Unix Makefiles',
-               'KDevelop3 - Unix Makefiles',
-               'Kate - Ninja',
-               'Kate - Unix Makefiles',
-           )
+           type=str
         )
 
     @classmethod
@@ -323,19 +308,25 @@ class DerivedTarget(Target):
             return None
 
     def hintForCMakeGenerator(self, generator_name, component):
+        if generator_name in ('Ninja', 'Unix Makefiles'):
+            return None
         try:
             name = self.getName()
             component_name = component.getName()
             return {
                 'Xcode':
-                    'to open the built project, run:\nopen ./build/%s/%s.xcodeproj' % (name, component_name),
+                    'a project file has been generated at ./build/%s/%s.xcodeproj' % (name, component_name),
                 'Sublime Text 2 - Ninja':
-                    'to open the built project, run:\nopen ./build/%s/%s.??' % (name, component_name),
+                    'a project file has been generated at ./build/%s/%s.sublime-project' % (name, component_name),
                 'Sublime Text 2 - Unix Makefiles':
-                    'to open the built project, run:\nopen ./build/%s/%s.??' % (name, component_name)
+                    'a project file has been generated at ./build/%s/%s.sublime-project' % (name, component_name),
+                'Eclipse CDT4 - Ninja':
+                    'a project file has been generated at ./build/%s/.project' % name,
+                'Eclipse CDT4 - Unix Makefiles':
+                    'a project file has been generated at ./build/%s/.project' % name
             }[generator_name]
         except KeyError:
-            return None
+            return 'project files for %s have been generated in ./build/%s' % (component_name, name)
 
     def exec_helper(self, cmd, builddir):
         ''' Execute the given command, returning an error message if an error occured

--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -270,12 +270,26 @@ class DerivedTarget(Target):
     def addBuildOptions(cls, parser):
         parser.add_argument('-G', '--cmake-generator', dest='cmake_generator',
            default='Ninja',
+           help='CMake generator to use (defaults to Ninja). You can use this '+
+           'to generate IDE project files instead, see cmake --help for '+
+           'possible generator names. Note that only Ninja or Unix Makefile '+
+           'based generators will work correctly with yotta.',
+           metavar='CMAKE_GENERATOR',
            choices=(
                'Unix Makefiles',
                'Ninja',
                'Xcode',
                'Sublime Text 2 - Ninja',
                'Sublime Text 2 - Unix Makefiles'
+               'CodeBlocks - Ninja',
+               'CodeBlocks - Unix Makefiles',
+               'CodeLite - Ninja',
+               'CodeLite - Unix Makefiles',
+               'Eclipse CDT4 - Ninja',
+               'Eclipse CDT4 - Unix Makefiles',
+               'KDevelop3 - Unix Makefiles',
+               'Kate - Ninja',
+               'Kate - Unix Makefiles',
            )
         )
 


### PR DESCRIPTION
For example:

```sh
yotta build -G "Eclipse CDT4 - Ninja"
```

```sh
yotta build -G "Sublime Text 2 - Ninja"
```

```sh
yotta build -G "KDevelop3 - Ninja"
```