### PR TITLE
Command-line config support

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -21,6 +21,12 @@ Additional Options that can be used with all subcommands:
 
  * `yotta --plain <subcommand>`: Don't use coloured output.
  * `yotta --noninteractive <subcommand>`: Don't wait for user input.
+ * `yotta --target <targetname>`: Override the currently set target for this
+   command (useful when isolating several instances of yotta)
+ * `yotta --config <configfile or JSON>`: Override the target and
+   application-defined [configuration](/reference/config.html). This is useful
+   in CI infrastructure to easily change the configuration for a particular
+   build.
 
 ## <a href="#yotta-init" name="yotta-init">#</a> yotta init
 #### Synopsis
@@ -142,6 +148,7 @@ Options:
 yotta test
 yotta test --list all
 yotta test -n my-test
+yotta test --config="path/to/test-config.json"
 ```
    
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -5,11 +5,6 @@ section: reference/config
 ---
 
 # Configuration System Reference
-
-**NOTE: The configuration system is currently experimental. Some of the
-behaviour described below may change in backwards-icompatible ways with minor
-updates to yotta.**
-
 yotta provides a flexible configuration system that can be used to control how
 modules are built based on information provided by [target
 descriptions](/tutorial/targets.html), optionally extended by a `config.json`
@@ -18,13 +13,28 @@ file in the application.
 This configuration information can be used to control a module's dependencies,
 and is also made available to code.
 
-<a name="defining"></a>
-## Defining Configuration Data
-Configuration data is defined in two places: [target descriptions](/tutorial/targets.html), and
-[executable applications](/tutorial/tutorial.html#Creating%20an%20Executable).
+## <a href="#viewing" name="viewing">#</a> Viewing Configuration Data
+Use the [yotta config](/reference/commands.html#yotta-config) to view the current
+configuration data, merged from all sources. For example:
+
+```sh
+> yotta config
+{
+  "mbed-os": {
+    "stdio": {
+      "baud": 115200, // command-line config
+      "default-baud": 9600 // mbed-gcc
+...
+}
+```
+
+## <a href="#defining" name="defining">#</a> Defining Configuration Data
+Configuration data is principally defined in two places: [target
+descriptions](/tutorial/targets.html), and [executable
+applications](/tutorial/tutorial.html#Creating%20an%20Executable).
 
 
-### Target Config Data
+### <a href="#target-config" name="target-config">#</a> Target Config Data
 The config data defined by targets can be used to make software modules compile
 across a wide range of different target hardware. For example, it might
 describe things like the frequency of a
@@ -35,7 +45,7 @@ Software that uses this hardware can then run on different targets, choosing
 the correct frequency to use for the UART communication by reading it from the
 configuration data.
 
-#### Config Data in target.json
+#### <a href="#target-json-config" name="target-json-config">#</a> Config Data in target.json
 To define config data in a target's target.json file, use the `"config":`
 property, for example:
 
@@ -53,7 +63,7 @@ property, for example:
 }
 ```
 
-#### Overriding Config Data in Derived Targets
+#### <a href="#target-config-inheritance" name="target-config-inheritance">#</a> Overriding Config Data in Derived Targets
 If a target [inherits](/tutorial/targets.html#inheriting) from a more generic
 target, then the config data in the more-derived target overrides data
 inherited from the base target.
@@ -97,7 +107,7 @@ config`](/reference/commands.html#yotta-config) subcommand), would be:
 }
 ```
 
-### Application Config Data
+### <a href="#app-config" name="app-config">#</a> Application Config Data
 An executable application may define additional config data to that provided by
 the selected target. To do this, the application should include a file called
 `config.json` alongside its `module.json` file.
@@ -113,15 +123,34 @@ If you find yourself copying & pasting `config.json` data between many
 applications, consider if deriving and publishing [your own
 target](/tutorial/targets.html) would be preferable.
 
+#### <a href="#commandline-config" name="commandline-config">#</a> Command-line Config data
+You can use the `--config` command-line option to provide further config info
+which extends or overrides the target and application-provided config.
 
-### Config Data Syntax
+Either a path to a JSON file, or literal JSON on the command line. For example
+
+```sh
+yotta --config=./path/to/config/file install
+yotta --config='{"mbed-os":{"stdio":{"baud":115200}}}' build
+```
+
+**NOTE:** it is recommended to not use this as part of your normal build
+process (as it will make it hard for someone else to reproduce your build), but
+passing config on the command line can be useful when testing your modules in
+order to easily switch between building different possible configurations.
+
+Normally the configuration for your application should be in either
+the target description for the board being used, or in the application-specific
+config.json file.
+
+
+### <a href="#syntax" name="syntax">#</a> Config Data Syntax
 The yotta config system accepts almost any JSON data, apart from Array objects.
 Array objects are not supported due to the ambiguity of merging inherited array
 objects.
 
 
-<a name="using"></a>
-## Using Configuration Data
+## <a href="#using" name="using">#</a> Using Configuration Data
 Modules can use the configuration data that has been defined to change their
 behaviour. In general it is best to minimise the amount of configuration that
 your module requires to the absolute minimum possible. This makes it easier
@@ -153,7 +182,7 @@ the config data than what `betterlog` expects.
 currently being considered. This would formalise the constraints modules have
 on what configuration may be defined.**
 
-### Controlling Dependencies
+### <a href="#control-dependencies" name="control-dependencies">#</a> Controlling Dependencies
 
 Config data can be used in the [targetDependencies
 section](/reference/module.html#targetDependencies) of `module.json` files.
@@ -212,7 +241,7 @@ And the targetDependencies:
 
 Then modules 1, 2, 3 and 4 will be included as dependencies, but `module-5` will not.
 
-### Using Configuration In Code
+### <a href="#use-in-code" name="use-in-code">#</a> Using Configuration In Code
 
 The config data is made available as preprocessor definitions, so that it can
 be tested at compile-time.
@@ -245,7 +274,7 @@ JSON boolean values are converted to 1 or 0, and `null` values are converted to 
 These definitions are defined through a pre-include file called
 `yotta_config.h` which is generated in the root of the build directory.
 
-### Using Configuration in CMakeLists
+### <a href="#use-in-cmake" name="use-in-cmake">#</a> Using Configuration in CMakeLists
 
 The config data is also made accessible to any custom CMakeLists.txt that have
 been written to control the build of a module. The CMake definitions are nearly

--- a/yotta/build.py
+++ b/yotta/build.py
@@ -18,8 +18,11 @@ from .lib import cmakegen
 from .lib import target
 # install, , install subcommand, internal
 from . import install
+# --config option, , , internal
+from . import options
 
 def addOptions(parser, add_build_targets=True):
+    options.config.addTo(parser)
     parser.add_argument('-g', '--generate-only', dest='generate_only',
         action='store_true', default=False,
         help='Only generate CMakeLists, don\'t run CMake or build'
@@ -64,7 +67,7 @@ def installAndBuild(args, following_args):
         return {'status':1}
 
     try:
-        target, errors = c.satisfyTarget(args.target)
+        target, errors = c.satisfyTarget(args.target, additional_config=args.config)
     except access_common.AccessException as e:
         logging.error(e)
         return {'status':1}

--- a/yotta/config.py
+++ b/yotta/config.py
@@ -9,9 +9,11 @@ import logging
 
 # validate, , validate things, internal
 from .lib import validate
+# --config option, , , internal
+from . import options
 
 def addOptions(parser):
-    pass
+    options.config.addTo(parser)
 
 def execCommand(args, following_args):
     c = validate.currentDirectoryModule()
@@ -22,7 +24,7 @@ def execCommand(args, following_args):
         logging.error('No target has been set, use "yotta target" to set one.')
         return 1
 
-    target, errors = c.satisfyTarget(args.target)
+    target, errors = c.satisfyTarget(args.target, additional_config=args.config)
     if errors:
         for error in errors:
             logging.error(error)

--- a/yotta/config.py
+++ b/yotta/config.py
@@ -6,14 +6,18 @@
 # standard library modules, , ,
 import json
 import logging
+import sys
 
 # validate, , validate things, internal
 from .lib import validate
+# utils, , miscellaneous utilities, internal
+from .lib.utils import islast
 # --config option, , , internal
 from . import options
 
 def addOptions(parser):
     options.config.addTo(parser)
+    options.plain.addTo(parser)
 
 def execCommand(args, following_args):
     c = validate.currentDirectoryModule()
@@ -32,5 +36,51 @@ def execCommand(args, following_args):
 
     config = target.getMergedConfig()
 
-    print(json.dumps(config, indent=2, separators=(',', ': ')))
+    if not args.plain:
+        # then display blame information with nice colours :)
+        dumpWithBlame(config, target.getConfigBlame())
+        sys.stdout.write('\n')
+    else:
+        print(json.dumps(config, indent=2, separators=(',', ': ')))
 
+def dumpWithBlame(config, blame, indent=''):
+    # colorama, BSD 3-Clause license, cross-platform terminal colours, pip install colorama
+    import colorama
+    DIM       = colorama.Style.DIM       #pylint: disable=no-member
+    RESET_ALL = colorama.Style.RESET_ALL #pylint: disable=no-member
+    RESET_COL = colorama.Fore.RESET      #pylint: disable=no-member
+    # true/false = green/red:
+    GREEN     = colorama.Fore.GREEN      #pylint: disable=no-member
+    RED       = colorama.Fore.RED        #pylint: disable=no-member
+    # numbers = blue
+    BLUE      = colorama.Fore.BLUE       #pylint: disable=no-member
+    # strings = magenta
+    MAGENTA   = colorama.Fore.MAGENTA    #pylint: disable=no-member
+
+    sys.stdout.write('{')
+    if len(config):
+        sys.stdout.write('\n')
+        for (k, val), last in islast(config.items()):
+            sys.stdout.write(indent+'  ')
+            sys.stdout.write('"' + k + '": ')
+            if isinstance(val, dict):
+                dumpWithBlame(val, blame.get(k, {}), indent+'  ')
+                if not last:
+                    sys.stdout.write(',')
+            else:
+                if val is True:
+                    sys.stdout.write(GREEN + 'true' + RESET_COL)
+                elif val is False:
+                    sys.stdout.write(RED + 'false' + RESET_COL)
+                elif isinstance(val, int) or isinstance(val, float):
+                    sys.stdout.write(BLUE + str(val) + RESET_COL)
+                else:
+                    # must be a string
+                    sys.stdout.write('"'+MAGENTA + str(val) + RESET_COL+'"')
+                if not last:
+                    sys.stdout.write(',')
+                if k in blame:
+                    sys.stdout.write(' '+DIM+'// ' + blame[k])
+            sys.stdout.write(RESET_ALL + '\n')
+        sys.stdout.write(indent)
+    sys.stdout.write('}')

--- a/yotta/debug.py
+++ b/yotta/debug.py
@@ -9,9 +9,12 @@ import logging
 
 # validate, , validate things, internal
 from .lib import validate
+# --config option, , , internal
+from . import options
 
 
 def addOptions(parser):
+    options.config.addTo(parser)
     parser.add_argument('program', default=None,
         help='name of the program to be debugged'
     )
@@ -24,7 +27,7 @@ def execCommand(args, following_args):
     if not c:
         return 1
 
-    target, errors = c.satisfyTarget(args.target)
+    target, errors = c.satisfyTarget(args.target, additional_config=args.config)
     if errors:
         for error in errors:
             logging.error(error)

--- a/yotta/install.py
+++ b/yotta/install.py
@@ -18,11 +18,14 @@ from .lib import access_common
 
 # folders, , get places to install things, internal
 from .lib import folders
+# --config option, , , internal
+from . import options
 
 GitHub_Ref_RE = re.compile('[a-zA-Z0-9-]*/([a-zA-Z0-9-]*)')
 
 
 def addOptions(parser):
+    options.config.addTo(parser)
     parser.add_argument('component', default=None, nargs='?',
         help='If specified, install this module instead of installing '+
              'the dependencies of the current module.'
@@ -83,7 +86,7 @@ def installDeps(args, current_component):
     if not args.target:
         logging.error('No target has been set, use "yotta target" to set one.')
         return 1
-    target, errors = current_component.satisfyTarget(args.target)
+    target, errors = current_component.satisfyTarget(args.target, additional_config=args.config)
     if errors:
         for error in errors:
             logging.error(error)
@@ -114,7 +117,7 @@ def installComponentAsDependency(args, current_component):
         logging.debug(str(current_component.getError()))
         logging.error('The current directory does not contain a valid module.')
         return -1
-    target, errors = current_component.satisfyTarget(args.target)
+    target, errors = current_component.satisfyTarget(args.target, additional_config=args.config)
     if errors:
         for error in errors:
             logging.error(error)

--- a/yotta/lib/component.py
+++ b/yotta/lib/component.py
@@ -565,7 +565,7 @@ class Component(pack.Pack):
                            test = test
         )
 
-    def satisfyTarget(self, target_name_and_version, update_installed=False):
+    def satisfyTarget(self, target_name_and_version, update_installed=False, additional_config=None):
         ''' Ensure that the specified target name (and optionally version,
             github ref or URL) is installed in the targets directory of the
             current component
@@ -574,10 +574,11 @@ class Component(pack.Pack):
         if self.isApplication():
             application_dir = self.path
         return target.getDerivedTarget(
-            target_name_and_version,
-            self.targetsPath(),
-            application_dir = application_dir,
-            update_installed = update_installed
+                                target_name_and_version,
+                                self.targetsPath(),
+              application_dir = application_dir,
+             update_installed = update_installed,
+            additional_config = additional_config
         )
 
     def installedDependencies(self):

--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -61,7 +61,8 @@ def getDerivedTarget(
                    targets_path,
                 application_dir = None,
                 install_missing = True,
-               update_installed = False
+               update_installed = False,
+              additional_config = None
     ):
     ''' Get the specified target description, optionally ensuring that it (and
         all dependencies) are installed in targets_path.

--- a/yotta/lib/utils.py
+++ b/yotta/lib/utils.py
@@ -1,0 +1,20 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+
+# utility function to indicate whether the current item is the last one in a
+# generator
+def islast(generator):
+    ''' indicate whether the current item is the last one in a generator
+    '''
+    next_x = None
+    first = True
+    for x in generator:
+        if not first:
+            yield (next_x, False)
+        next_x = x
+        first = False
+    if not first:
+        yield (next_x, True)

--- a/yotta/link_target.py
+++ b/yotta/link_target.py
@@ -18,24 +18,24 @@ from .lib import validate
 from .lib import folders
 
 def addOptions(parser):
-    parser.add_argument('target', default=None, nargs='?',
+    parser.add_argument('link_target', default=None, nargs='?',
         help='Link a globally installed (or globally linked) target into '+
              'the current target\'s dependencies. If ommited, globally '+
              'link the current target.'
     )
 
 def execCommand(args, following_args):
-    if args.target:
+    if args.link_target:
         c = validate.currentDirectoryModule()
         if not c:
             return 1
-        err = validate.targetNameValidationError(args.target)
+        err = validate.targetNameValidationError(args.link_target)
         if err:
             logging.error(err)
             return 1
         fsutils.mkDirP(os.path.join(os.getcwd(), 'yotta_targets'))
-        src = os.path.join(folders.globalTargetInstallDirectory(), args.target)
-        dst = os.path.join(os.getcwd(), 'yotta_targets', args.target)
+        src = os.path.join(folders.globalTargetInstallDirectory(), args.link_target)
+        dst = os.path.join(os.getcwd(), 'yotta_targets', args.link_target)
         # if the target is already installed, rm it
         fsutils.rmRf(dst)
     else:
@@ -46,7 +46,7 @@ def execCommand(args, following_args):
         src = os.getcwd()
         dst = os.path.join(folders.globalTargetInstallDirectory(), t.getName())
 
-    if args.target:
+    if args.link_target:
         realsrc = fsutils.realpath(src)
         if src == realsrc:
             logging.warning(

--- a/yotta/list.py
+++ b/yotta/list.py
@@ -20,8 +20,11 @@ from .lib import access
 from .lib import fsutils
 # Registry Access, , access packages in the registry, internal
 from .lib.registry_access import friendlyRegistryName
+# --config option, , , internal
+from . import options
 
 def addOptions(parser):
+    options.config.addTo(parser)
     parser.add_argument('--all', '-a', dest='show_all', default=False, action='store_true',
         help='Show all dependencies (including repeats, and test-only dependencies)'
     )
@@ -42,7 +45,7 @@ def execCommand(args, following_args):
         logging.error('No target has been set, use "yotta target" to set one.')
         return 1
 
-    target, errors = c.satisfyTarget(args.target)
+    target, errors = c.satisfyTarget(args.target, additional_config=args.config)
     if errors:
         for error in errors:
             logging.error(error)

--- a/yotta/list.py
+++ b/yotta/list.py
@@ -14,6 +14,8 @@ import colorama
 
 # validate, , validate things, internal
 from .lib import validate
+# utils, , miscellaneous utilities, internal
+from .lib.utils import islast
 # access, , get components (and check versions), internal
 from .lib import access
 # fsutils, , misc filesystem utils, internal
@@ -94,17 +96,6 @@ def formatJsonDeps(target, available_components, list_all):
             }
             d[c]['dependencies'][dep.name]=dd
     return json.dumps(d)
-
-def islast(generator):
-    next_x = None
-    first = True
-    for x in generator:
-        if not first:
-            yield (next_x, False)
-        next_x = x
-        first = False
-    if not first:
-        yield (next_x, True)
 
 def putln(x):
     if u'unicode' in str(type(x)):

--- a/yotta/login.py
+++ b/yotta/login.py
@@ -11,11 +11,15 @@ import logging
 from .lib import auth
 # Registry Access, , access modules in the registry, internal
 from .lib import registry_access
+# --registry option, , , internal
+from . import options
 
 def addOptions(parser):
-    # set the registry URL to save an API key for (this argument is also a
-    # top-level one, use a different dest here so we can distinguish)
-    parser.add_argument('--registry', dest='_registry', help=argparse.SUPPRESS)
+    # accept top-level registry option at subcommand level too
+    options.registry.addTo(parser)
+    options.noninteractive.addTo(parser)
+    options.plain.addTo(parser)
+
     # pass the API key for logging into this registry (it will be saved, and
     # used for future requests to this registry)
     parser.add_argument('--apikey', '-k', dest='apikey', help=argparse.SUPPRESS)
@@ -31,10 +35,9 @@ def addOptions(parser):
     )
 
 def execCommand(args, following_args):
-    registry = args._registry or args.registry
+    registry = args.registry
     if args.apikey:
         registry_access.setAPIKey(registry, args.apikey)
-
     try:
         provider = None
         if args.github_login:

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -74,6 +74,7 @@ def main():
     options.noninteractive.addTo(parser)
     options.registry.addTo(parser)
     options.target.addTo(parser)
+    options.config.addTo(parser)
 
     def addParser(name, module_name, description, help=None):
         if help is None:

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -12,17 +12,8 @@ import argcomplete
 
 # standard library modules, , ,
 import argparse
-import logging
 import sys
-from functools import reduce
 import os
-
-# detect, , detect things about the system, internal
-from .lib import detect
-# logging setup, , setup the logging system, internal
-from .lib import logging_setup
-# options, , common argument parser options, internal
-import options
 
 # globalconf, share global arguments between modules, internal
 import yotta.lib.globalconf as globalconf
@@ -42,40 +33,6 @@ def splitList(l, at_value):
             r[-1].append(x)
     return r
 
-# (instead of subclassing argparse._SubParsersAction, we monkey-patch it,
-#  because argcomplete has special-cases for the _SubParsersAction class that
-#  it's impossible to extend to another class)
-#
-# add a add_parser_async function, which allows a subparser to be added whose
-# options are not evaluated until the subparser has been selected. This allows
-# us to defer loading the modules for all the subcommands until they are
-# actually:
-def _SubParsersAction_addParserAsync(self, name, *args, **kwargs):
-    if not 'callback' in kwargs:
-        raise ValueError('callback=fn(parser) argument must be specified')
-    callback = kwargs['callback']
-    del kwargs['callback']
-    parser = self.add_parser(name, *args, **kwargs)
-    parser._lazy_load_callback = callback
-    return None
-argparse._SubParsersAction.add_parser_async = _SubParsersAction_addParserAsync
-
-def _wrapSubParserActionCall(orig_call):
-    def wrapped_call(self, parser, namespace, values, option_string=None):
-        parser_name = values[0]
-        if parser_name in self._name_parser_map:
-            subparser = self._name_parser_map[parser_name]
-            if hasattr(subparser, '_lazy_load_callback'):
-                # the callback is responsible for adding the subparser's own
-                # arguments:
-                subparser._lazy_load_callback(subparser)
-        # now we can go ahead and call the subparser action: its arguments are
-        # now all set up
-        return orig_call(self, parser, namespace, values, option_string)
-    return wrapped_call
-argparse._SubParsersAction.__call__ = _wrapSubParserActionCall(argparse._SubParsersAction.__call__)
-
-
 # Override the argparse default version action so that we can avoid importing
 # pkg_resources (which is slowww) unless someone has actually asked for the
 # version
@@ -85,11 +42,21 @@ class FastVersionAction(argparse.Action):
         sys.stdout.write(pkg_resources.require("yotta")[0].version + '\n') #pylint: disable=not-callable
         sys.exit(0)
 
-
 def main():
-    logging_setup.init(level=logging.INFO, enable_subsystems=None, plain=False)
+    # standard library modules, , ,
+    import logging
+    from functools import reduce
 
-    parser = argparse.ArgumentParser(
+    # logging setup, , setup the logging system, internal
+    from .lib import logging_setup
+    # options, , common argument parser options, internal
+    import options
+
+    logging_setup.init(level=logging.INFO, enable_subsystems=None, plain=False)
+    
+    # we override many argparse things to make options more re-usable across
+    # subcommands, and allow lazy loading of subcommand modules:
+    parser = options.parser.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
         description='Build software using re-usable components.\n'+
         'For more detailed help on each subcommand, run: yotta <subcommand> --help'
@@ -99,23 +66,14 @@ def main():
     parser.add_argument('--version', nargs=0, action=FastVersionAction,
         help='display the version'
     )
+
+    # add re-usable top-level options which subcommands may also accept
     options.verbosity.addTo(parser)
     options.debug.addTo(parser)
     options.plain.addTo(parser)
-
-    parser.add_argument('-t', '--target', dest='target',
-        default=detect.defaultTarget(),
-        help='Set the build and dependency resolution target (targetname[,versionspec_or_url])'
-    )
-
-    parser.add_argument('--noninteractive', '-n', dest='interactive',
-        action='store_false', default=True,
-        help="Do not wait for user interaction (for example to log in), fail instead."
-    )
-
-    parser.add_argument(
-        '--registry', default=None, dest='registry', help=argparse.SUPPRESS
-    )
+    options.noninteractive.addTo(parser)
+    options.registry.addTo(parser)
+    options.target.addTo(parser)
 
     def addParser(name, module_name, description, help=None):
         if help is None:

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -50,7 +50,7 @@ def main():
     # logging setup, , setup the logging system, internal
     from .lib import logging_setup
     # options, , common argument parser options, internal
-    import options
+    import yotta.options as options
 
     logging_setup.init(level=logging.INFO, enable_subsystems=None, plain=False)
 

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -53,7 +53,7 @@ def main():
     import options
 
     logging_setup.init(level=logging.INFO, enable_subsystems=None, plain=False)
-    
+
     # we override many argparse things to make options more re-usable across
     # subcommands, and allow lazy loading of subcommand modules:
     parser = options.parser.ArgumentParser(

--- a/yotta/options/__init__.py
+++ b/yotta/options/__init__.py
@@ -3,7 +3,10 @@
 # Licensed under the Apache License, Version 2.0
 # See LICENSE file for details.
 
-from . import verbosity
-from . import debug
-from . import plain
-
+import verbosity
+import debug
+import plain
+import noninteractive
+import registry
+import target
+import parser

--- a/yotta/options/__init__.py
+++ b/yotta/options/__init__.py
@@ -3,10 +3,15 @@
 # Licensed under the Apache License, Version 2.0
 # See LICENSE file for details.
 
+# import our re-usable options modules (all internal)
 import verbosity
 import debug
 import plain
 import noninteractive
 import registry
 import target
+import config
+
+# this modifies argparse when it's imported:
 import parser
+

--- a/yotta/options/__init__.py
+++ b/yotta/options/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+from . import verbosity
+from . import debug
+from . import plain
+

--- a/yotta/options/__init__.py
+++ b/yotta/options/__init__.py
@@ -4,14 +4,14 @@
 # See LICENSE file for details.
 
 # import our re-usable options modules (all internal)
-import verbosity
-import debug
-import plain
-import noninteractive
-import registry
-import target
-import config
+from . import verbosity
+from . import debug
+from . import plain
+from . import noninteractive
+from . import registry
+from . import target
+from . import config
 
 # this modifies argparse when it's imported:
-import parser
+from . import parser
 

--- a/yotta/options/config.py
+++ b/yotta/options/config.py
@@ -1,0 +1,28 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library options
+from argparse import Action
+
+
+class ConfigAction(Action):
+    def __init__(self, *args, **kwargs):
+        kwargs['nargs'] = 1
+        self.dest = kwargs['dest']
+        super(ConfigAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values[0])
+
+def addTo(parser):
+    parser.add_argument(
+        '--config', default=None, dest='config', help=
+        "Specify the path to a JSON configuration file to extend the build "+
+        "configuration provided by the target. This is most useful for "+
+        "ensuring test coverage of the ways that different targets will "+
+        "cause the module to build without building for different targets",
+        metavar="path/to/config.json",
+        action=ConfigAction
+    )

--- a/yotta/options/debug.py
+++ b/yotta/options/debug.py
@@ -1,0 +1,29 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library options
+from argparse import Action, SUPPRESS
+
+# logging setup, , setup the logging system, internal
+from yotta.lib import logging_setup
+
+class DebugSubsystemsAction(Action):
+    def __init__(self, *args, **kwargs):
+        self.subsystems = []
+        kwargs['nargs'] = 1
+        super(DebugSubsystemsAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        self.subsystems += values
+        logging_setup.setEnabledModules(self.subsystems)
+
+def addTo(parser):
+    parser.add_argument('-d', '--debug', action=DebugSubsystemsAction,
+        metavar='SUBSYS',
+        help=SUPPRESS
+        #help='specify subsystems to debug: use in conjunction with -v to '+
+        #     'increase the verbosity only for specified subsystems'
+    )
+

--- a/yotta/options/noninteractive.py
+++ b/yotta/options/noninteractive.py
@@ -1,0 +1,24 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library options
+from argparse import Action
+
+class Noninteractive(Action):
+    def __init__(self, *args, **kwargs):
+        kwargs['nargs'] = 0
+        kwargs['metavar'] = None
+        self.dest = kwargs['dest']
+        super(Noninteractive, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, False)
+
+def addTo(parser):
+    parser.add_argument('--noninteractive', '-n', dest='interactive',
+        action=Noninteractive, default=True,
+        help="Do not wait for user interaction (for example to log in), fail instead."
+    )
+

--- a/yotta/options/parser.py
+++ b/yotta/options/parser.py
@@ -1,0 +1,55 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library modules, , ,
+import argparse
+import copy
+
+# (instead of subclassing argparse._SubParsersAction, we monkey-patch it,
+#  because argcomplete has special-cases for the _SubParsersAction class that
+#  it's impossible to extend to another class)
+#
+# add a add_parser_async function, which allows a subparser to be added whose
+# options are not evaluated until the subparser has been selected. This allows
+# us to defer loading the modules for all the subcommands until they are
+# actually:
+def _SubParsersAction_addParserAsync(self, name, *args, **kwargs):
+    if not 'callback' in kwargs:
+        raise ValueError('callback=fn(parser) argument must be specified')
+    callback = kwargs['callback']
+    del kwargs['callback']
+    parser = self.add_parser(name, *args, **kwargs)
+    parser._lazy_load_callback = callback
+    return None
+argparse._SubParsersAction.add_parser_async = _SubParsersAction_addParserAsync
+
+def _wrapSubParserActionCall(orig_call):
+    def wrapped_call(self, parser, namespace, values, option_string=None):
+        parser_name = values[0]
+        if parser_name in self._name_parser_map:
+            subparser = self._name_parser_map[parser_name]
+            if hasattr(subparser, '_lazy_load_callback'):
+                # the callback is responsible for adding the subparser's own
+                # arguments:
+                subparser._lazy_load_callback(subparser)
+        # now we can go ahead and call the subparser action: its arguments are
+        # now all set up
+        original_values = copy.copy(vars(namespace))
+        ret = orig_call(self, parser, namespace, values, option_string)
+        # replace any argument value that was clobbered by a "None" value with
+        # its value from the root parser. (the subparser re-sets the default
+        # values for options with are re-used between the root and sub-parsers)
+        for k, v in original_values.items():
+            if v is not None and hasattr(namespace, k):
+                if getattr(namespace, k) is None:
+                    setattr(namespace, k, v)
+        return ret
+    return wrapped_call
+argparse._SubParsersAction.__call__ = _wrapSubParserActionCall(argparse._SubParsersAction.__call__)
+
+# we don't actually modify the parser itself (actually its impossible to do the
+# above modifications by subclassing :()
+ArgumentParser = argparse.ArgumentParser
+

--- a/yotta/options/plain.py
+++ b/yotta/options/plain.py
@@ -1,0 +1,27 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library options
+from argparse import Action
+
+# logging setup, , setup the logging system, internal
+from yotta.lib import logging_setup
+
+class PlainAction(Action):
+    def __init__(self, *args, **kwargs):
+        kwargs['nargs'] = 0
+        kwargs['metavar'] = None
+        self.dest = kwargs['dest']
+        super(PlainAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, True)
+        logging_setup.setPlain(True)
+
+def addTo(parser):
+    parser.add_argument('--plain', dest='plain', action=PlainAction,
+        default=False, help="Use a simple output format with no colours"
+    )
+

--- a/yotta/options/plain.py
+++ b/yotta/options/plain.py
@@ -22,6 +22,6 @@ class PlainAction(Action):
 
 def addTo(parser):
     parser.add_argument('--plain', dest='plain', action=PlainAction,
-        default=False, help="Use a simple output format with no colours"
+        default=None, help="Use a simple output format with no colours"
     )
 

--- a/yotta/options/registry.py
+++ b/yotta/options/registry.py
@@ -1,0 +1,23 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library options
+from argparse import Action, SUPPRESS
+
+
+class RegistryAction(Action):
+    def __init__(self, *args, **kwargs):
+        kwargs['nargs'] = 1
+        self.dest = kwargs['dest']
+        super(RegistryAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values[0])
+
+def addTo(parser):
+    parser.add_argument(
+        '--registry', default=None, dest='registry', help=SUPPRESS,
+        action=RegistryAction
+    )

--- a/yotta/options/target.py
+++ b/yotta/options/target.py
@@ -16,7 +16,7 @@ class TargetAction(Action):
         super(TargetAction, self).__init__(*args, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, False)
+        setattr(namespace, self.dest, values[0])
 
 def addTo(parser):
     parser.add_argument('-t', '--target', dest='target',

--- a/yotta/options/target.py
+++ b/yotta/options/target.py
@@ -1,0 +1,26 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library options
+from argparse import Action
+
+# detect, , detect things about the system, internal
+from yotta.lib import detect
+
+class TargetAction(Action):
+    def __init__(self, *args, **kwargs):
+        kwargs['nargs'] = 1
+        self.dest = kwargs['dest']
+        super(TargetAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, False)
+
+def addTo(parser):
+    parser.add_argument('-t', '--target', dest='target',
+        default=detect.defaultTarget(),
+        action=TargetAction,
+        help='Set the build and dependency resolution target (targetname[,versionspec_or_url])'
+    )

--- a/yotta/options/verbosity.py
+++ b/yotta/options/verbosity.py
@@ -1,0 +1,41 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library options
+from argparse import Action, SUPPRESS
+import logging
+
+# logging setup, , setup the logging system, internal
+from yotta.lib import logging_setup
+
+def logLevelFromVerbosity(v):
+    if v >= 4:
+        return logging.NOTSET
+    elif v == 3:
+        return logging.DEBUG
+    elif v == 2:
+        return logging.DEBUG+3
+    elif v == 1:
+        return logging.DEBUG+7
+    else:
+        return logging.INFO
+
+class VerbosityAction(Action):
+    def __init__(self, *args, **kwargs):
+        self.level = 0
+        kwargs['nargs'] = 0
+        kwargs['dest'] = SUPPRESS
+        super(VerbosityAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        self.level += 1
+        loglevel = logLevelFromVerbosity(self.level)
+        logging_setup.setLevel(loglevel)
+
+def addTo(parser):
+    parser.add_argument('-v', '--verbose', action=VerbosityAction,
+        default=0,
+        help='increase verbosity: can be used multiple times'
+    )

--- a/yotta/test/git_access.py
+++ b/yotta/test/git_access.py
@@ -69,8 +69,8 @@ class TestGitAccess(unittest.TestCase):
         self.assertTrue(v)
 
     def test_installDeps(self):
-        Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'install_test_deps'])
-        install.installComponent(Args(Test_Deps_Name, Test_Deps_Target, False, False, 'own'))
+        Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'install_test_deps', 'config'])
+        install.installComponent(Args(Test_Deps_Name, Test_Deps_Target, False, False, 'own', {}))
 
 
 if __name__ == '__main__':

--- a/yotta/test/github_access.py
+++ b/yotta/test/github_access.py
@@ -38,13 +38,13 @@ class TestGitHubAccess(unittest.TestCase):
 
     @unittest.skipIf(not hasGithubConfig(), "a github authtoken must be specified for this test (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)")
     def test_installDeps(self):
-        Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'install_test_deps'])
-        install.installComponent(Args(Test_Deps_Name, Test_Deps_Target, False, False, 'own'))
+        Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'install_test_deps', 'config'])
+        install.installComponent(Args(Test_Deps_Name, Test_Deps_Target, False, False, 'own', {}))
 
     @unittest.skipIf(not hasGithubConfig(), "a github authtoken must be specified for this test (run yotta login, or set YOTTA_GITHUB_AUTHTOKEN)")
     def test_branchAccess(self):
-        Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'install_test_deps'])
-        install.installComponent(Args(Test_Branch_Name, Test_Deps_Target, False, False, 'own'))
+        Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'install_test_deps', 'config'])
+        install.installComponent(Args(Test_Branch_Name, Test_Deps_Target, False, False, 'own', {}))
 
 
 if __name__ == '__main__':

--- a/yotta/test/hg_access.py
+++ b/yotta/test/hg_access.py
@@ -54,8 +54,8 @@ class TestHGAccess(unittest.TestCase):
         fsutils.rmRf(self.working_copy.directory)
 
     def test_installDeps(self):
-        Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'install_test_deps'])
-        install.installComponent(Args(Test_Deps_Name, Test_Deps_Target, False, False, 'own'))
+        Args = namedtuple('Args', ['component', 'target', 'act_globally', 'install_linked', 'install_test_deps', 'config'])
+        install.installComponent(Args(Test_Deps_Name, Test_Deps_Target, False, False, 'own', {}))
 
     def test_availableVersions(self):
         versions = self.working_copy.availableVersions()

--- a/yotta/test_subcommand.py
+++ b/yotta/test_subcommand.py
@@ -16,9 +16,12 @@ from .lib import target
 from .lib import fsutils
 # build, , build subcommand, internal
 from . import build
+# --config option, , , internal
+from . import options
 
 
 def addOptions(parser):
+    options.config.addTo(parser)
     parser.add_argument(
         "--list", '-l', dest='list_only', default=False, action='store_true',
         help='List the tests that would be run, but don\'t run them. Implies --no-build'
@@ -115,7 +118,7 @@ def execCommand(args, following_args):
     if not c:
         return 1
 
-    target, errors = c.satisfyTarget(args.target)
+    target, errors = c.satisfyTarget(args.target, additional_config=args.config)
     if errors:
         for error in errors:
             logging.error(error)

--- a/yotta/update.py
+++ b/yotta/update.py
@@ -8,8 +8,11 @@ import logging
 
 # validate, , validate things, internal
 from .lib import validate
+# --config option, , , internal
+from . import options
 
 def addOptions(parser):
+    options.config.addTo(parser)
     parser.add_argument('component', default=None, nargs='?',
         help='If specified, update (and if necessary install) this module '+
              'instead of updating the dependencies of the current module.'
@@ -31,7 +34,7 @@ def execCommand(args, following_args):
     if not args.target:
         logging.error('No target has been set, use "yotta target" to set one.')
         return 1
-    target, errors = c.satisfyTarget(args.target, update_installed=True)
+    target, errors = c.satisfyTarget(args.target, update_installed=True, additional_config=args.config)
     if errors:
         for error in errors:
             logging.error(error)


### PR DESCRIPTION
 * `yotta test --config=path/to/something.json`
 * `--config='{"something":true}'` also works
 * Improved output of `yotta config` to display where each line of config came from (also, colours)
 * some behind-the-scenes improvements to command line options that made this easier to implement

<img width="291" alt="screen shot 2015-12-10 at 16 36 06" src="https://cloud.githubusercontent.com/assets/3456211/11721953/41448f06-9f5e-11e5-833d-958e1c486950.png">

resolves #520 and #580