### PR TITLE
Add the facility for targets to apply custom CMake to all modules.

### DIFF
--- a/docs/reference/buildsystem.md
+++ b/docs/reference/buildsystem.md
@@ -17,8 +17,29 @@ using [CMake](http://cmake.org).
 yotta makes some useful information available to the modules being compiled, which
 can be embedded in the built binary or otherwise used at compile time. The
 majority of this information is defined by yotta's [configuration
-system](/reference/config.html), but if the yotta build information header is
-included, then you can also access other information:
+system](/reference/config.html), but some other information is also available.
+
+### Information Always Available
+The name of the library being built by the current module is available as
+`YOTTA_MODULE_NAME`, as if it were defined:
+
+```
+#define YOTTA_MODULE_NAME modulename-unquoted
+```
+
+No header needs to be included for this definition to be available.
+
+Use the [preprocessor stringification
+trick](https://gcc.gnu.org/onlinedocs/cpp/Stringification.html) to get the
+module name as a string, if desired. Note that this definition is **not**
+currently available when compiling tests, and there are other circumstances
+where using custom CMake can make it unavailable.
+
+
+### Information Available in the Build Info Header
+If the yotta build information header is included, then you can also access
+other information. Note that this header changes with every build (as it
+includes a build timestamp and unique ID), so do not include it unnecessarily.
 
 To include the yotta build information header:
 

--- a/docs/reference/target.md
+++ b/docs/reference/target.md
@@ -32,6 +32,10 @@ when building for different targets.
     }
   },
   "toolchain": "CMake/toolchain.cmake",
+  "cmakeIncludes": [
+    "CMake/enableXXX.cmake",
+    "CMake/debugYYY.cmake"
+  ]
   "scripts": {
     "debug": ["valinor", "--target", "K64F", "$program" ],
     "test": [ "mbed_test_wrapper", "--target", "K64F", "$program" ]
@@ -158,6 +162,18 @@ with the mbed target name of the development board.
 Path to the target's CMake toolchain file. If this target [inherits](#inherits)
 from another target that provides a functioning toolchain this property is
 optional.
+
+### <a href="#cmakeIncludes" name="cmakeIncludes">#</a> `cmakeIncludes`
+**type: Array of String (paths relative to target root directory)**
+
+List of CMake files which should be included in every module built. These can
+be used to modify the rules for building libraries/executables as necessary.
+For example, a target description might provide the ability to produce
+selected code-coverage information by appending code-coverage flags when
+compiling some selected subset of modules.
+
+The name of the library being built by the current module is available in the
+included cmake files as `YOTTA_MODULE_NAME`.
 
 ### <a href="#scripts" name="scripts">#</a> `scripts`
 **type: hash of script-name to command**

--- a/yotta/lib/cmake_fixups.py
+++ b/yotta/lib/cmake_fixups.py
@@ -35,7 +35,7 @@ def fixupEclipseProject(builddir, component):
 \t\t\t<name>%s-source</name>
 \t\t\t<type>2</type>
 \t\t\t<location>%s</location>
-\t\t</link>\n''' % (component.getName(), os.path.join(component.path, 'source'))
+\t\t</link>\n''' % (component.getName(), os.path.abspath(os.path.join(component.path, 'source')))
             )
 
 def fixupNinjaBackslashes(builddir):

--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -498,6 +498,7 @@ class CMakeGen(object):
                          "delegate_to": delegate_to_existing,
                   "delegate_build_dir": delegate_build_dir,
                  "active_dependencies": active_dependencies,
+                     "module_is_empty": module_is_empty,
                       "cmake_includes": self.target.getAdditionalIncludes()
         })
         self._writeFile(os.path.join(builddir, 'CMakeLists.txt'), file_contents)

--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -465,16 +465,17 @@ class CMakeGen(object):
                         component, builddir, [x[0] for x in immediate_dependencies.items() if not x[1].isTestDependency()]
                     ))
 
-        # generate the top-level toolchain file:
-        template = jinja_environment.get_template('toolchain.cmake')
-        file_contents = template.render({  #pylint: disable=no-member
-                               # toolchain files are provided in hierarchy
-                               # order, but the template needs them in reverse
-                               # order (base-first):
-            "toolchain_files": reversed(self.target.getToolchainFiles())
-        })
         toolchain_file_path = os.path.join(builddir, 'toolchain.cmake')
-        self._writeFile(toolchain_file_path, file_contents)
+        if toplevel:
+            # generate the top-level toolchain file:
+            template = jinja_environment.get_template('toolchain.cmake')
+            file_contents = template.render({  #pylint: disable=no-member
+                                   # toolchain files are provided in hierarchy
+                                   # order, but the template needs them in reverse
+                                   # order (base-first):
+                "toolchain_files": self.target.getToolchainFiles()
+            })
+            self._writeFile(toolchain_file_path, file_contents)
 
         # generate the top-level CMakeLists.txt
         template = jinja_environment.get_template('base_CMakeLists.txt')
@@ -496,7 +497,8 @@ class CMakeGen(object):
                  "config_include_file": self.config_include_file,
                          "delegate_to": delegate_to_existing,
                   "delegate_build_dir": delegate_build_dir,
-                 "active_dependencies": active_dependencies
+                 "active_dependencies": active_dependencies,
+                      "cmake_includes": self.target.getAdditionalIncludes()
         })
         self._writeFile(os.path.join(builddir, 'CMakeLists.txt'), file_contents)
 

--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -310,11 +310,24 @@ class DerivedTarget(Target):
 
     def getToolchainFiles(self):
         ''' return a list of toolchain file paths in override order (starting
-            at the bottom/leaf of the hierarchy and ending at the base)
+            at the bottom/leaf of the hierarchy and ending at the base).
+            The list is returned in the order they should be included
+            (most-derived last).
         '''
-        return [
+        return reversed([
             os.path.join(x.path, x.description['toolchain']) for x in self.hierarchy if 'toolchain' in x.description
-        ]
+        ])
+
+    def getAdditionalIncludes(self):
+        ''' Return the list of cmake files which are to be included by yotta in
+            every module built. The list is returned in the order they should
+            be included (most-derived last).
+        '''
+        return reversed([
+            os.path.join(t.path, include_file)
+                for t in self.hierarchy
+                for include_file in t.description.get('cmakeIncludes', [])
+        ])
 
     @classmethod
     def addBuildOptions(cls, parser):

--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -115,9 +115,14 @@ add_subdirectory(
 {% endfor %}
 {% endif %}
 
+{% if not module_is_empty %}
 # make YOTTA_MODULE_NAME available as a preprocessor symbol when
 # compiling this module:
 target_compile_definitions({{ component.getName() }} PRIVATE "-DYOTTA_MODULE_NAME={{ component.getName() }}")
+{% else %}
+# (not setting YOTTA_MODULE_NAME preprocessor definition as this module doesn't
+# have any sources to build)
+{% endif %}
 
 {% if cmake_includes %}
 # include .cmake files provided by the target:

--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -93,6 +93,10 @@ set(YOTTA_{{ dep.getName() | sanitizePreprocessorSymbol }}_VERSION_MINOR {{ dep.
 set(YOTTA_{{ dep.getName() | sanitizePreprocessorSymbol }}_VERSION_PATCH {{ dep.getVersion().patch() }})
 {% endfor %}
 
+# provide the name of the current module so that it's available to custom CMake
+# even if custom CMake does weird things with project()
+set(YOTTA_MODULE_NAME {{ component.getName() }})
+
 {% if delegate_to %}
 # delegate to an existing CMakeLists.txt:
 add_subdirectory(
@@ -108,5 +112,16 @@ add_subdirectory(
     "{{ srcdir | replaceBackslashes }}"
     "${CMAKE_BINARY_DIR}/{{ relpath | replaceBackslashes }}/{{ workingdir | replaceBackslashes }}"
 )
+{% endfor %}
+{% endif %}
+
+# make YOTTA_MODULE_NAME available as a preprocessor symbol when
+# compiling this module:
+target_compile_definitions({{ component.getName() }} PRIVATE "-DYOTTA_MODULE_NAME={{ component.getName() }}")
+
+{% if cmake_includes %}
+# include .cmake files provided by the target:
+{% for f in cmake_includes %}
+include("{{ f }}")
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
 * Targets can define cmakeIncludes which will be included in every module
 * Make YOTTA_MODULE_NAME available to both CMake and the preprocessor, so that
   custom CMake and modules can use it.
 * Update documentation correspondingly

Fixes #591 and #626 

@bremoran @bogdanm: could you check that this suits your needs?