### PR TITLE
Don't crash if creating a link fails

### DIFF
--- a/yotta/link.py
+++ b/yotta/link.py
@@ -44,9 +44,11 @@ def execCommand(args, following_args):
         src = os.getcwd()
         dst = os.path.join(folders.globalInstallDirectory(), c.getName())
 
+    broken_link = False
     if args.component:
         realsrc = fsutils.realpath(src)
         if src == realsrc:
+            broken_link = True
             logging.warning(
               ('%s -> %s -> ' % (dst, src)) + colorama.Fore.RED + 'BROKEN' + colorama.Fore.RESET #pylint: disable=no-member
             )
@@ -55,5 +57,11 @@ def execCommand(args, following_args):
     else:
         logging.info('%s -> %s' % (dst, src))
 
-    fsutils.symlink(src, dst)
+    try:
+        fsutils.symlink(src, dst)
+    except Exception as e:
+        if broken_link:
+            logging.error('failed to create link (create the first half of the link first)')
+        else:
+            logging.error('failed to create link: %s', e)
 


### PR DESCRIPTION
 * produce a useful error in the case that the second half failed because the
   first half hasn't been completed (this happens on windows)
 * Otherwise reduce the exception encountered to an error message.

Fixes #453