### PR TITLE
Hotfix: Fix breaking build under windows due to wrong backslash 

### DIFF
--- a/yotta/lib/templates/base_CMakeLists.txt
+++ b/yotta/lib/templates/base_CMakeLists.txt
@@ -127,6 +127,6 @@ target_compile_definitions({{ component.getName() }} PRIVATE "-DYOTTA_MODULE_NAM
 {% if cmake_includes %}
 # include .cmake files provided by the target:
 {% for f in cmake_includes %}
-include("{{ f }}")
+include("{{ f  | replaceBackslashes }}")
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Builds break under windows with yotta version 0.12.0, due to backslashes not being replaced correctly.

```
CMake Error at ym/uvisor-lib/CMakeLists.txt:57 (include):
  Syntax error in cmake code at

    C:/Users/[username]/example-mbedos-blinky/build/frdm-k64f-gcc/ym/uvisor-lib/CMakeLists.txt:57

  when parsing string

    C:\Users\[username]\example-mbedos-blinky\yotta_targets\mbed-gcc\coverage/coverage.cmake

  Invalid escape sequence \U
```
The issue is [in the Jinja2 template for the CmMakeList.txt](https://github.com/ARMmbed/yotta/blob/master/yotta/lib/templates/base_CMakeLists.txt#L127-L132), where the `replaceBackslashes` filter is not applied.
```
{% if cmake_includes %}
# include .cmake files provided by the target:
{% for f in cmake_includes %}
include("{{ f }}")      # needs to be include("{{ f | replaceBackslashes }}")
{% endfor %}
{% endif %}
```

This PR adds this filter, which allows compilation on Windows again.

@autopulated @bogdanm @bremoran @mlnx 