### PR TITLE
Fixed tiny typo in instructions for linux

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -220,7 +220,7 @@ Pin-Priority: 1001
 e.g.
 
 ```sh
-sudo echo -e "Explanation: get gcc-arm-none-eabi from ppa\nPackage: gcc-arm-none-eabi\nPin: origin \"ppa.launchpad.net\"\nPin-Priority: 1001" | sudo tee /etc/apt/preferences.d/gcc-arm-none-eabi'
+sudo echo -e "Explanation: get gcc-arm-none-eabi from ppa\nPackage: gcc-arm-none-eabi\nPin: origin \"ppa.launchpad.net\"\nPin-Priority: 1001" | sudo tee /etc/apt/preferences.d/gcc-arm-none-eabi
 ```
 
 Then install the package as normal:


### PR DESCRIPTION
If someone accidentally thinks this quote should be a part of the command, it's easy to mess up the installation without noticing.