### PR TITLE
Allow 'lib' directory to be specified in module.json

### DIFF
--- a/docs/reference/module.md
+++ b/docs/reference/module.md
@@ -363,6 +363,20 @@ of the contents of the source directory, set:
   "bin": "./source"
 ```
 
+### `lib`
+**type: String (path relative to module root)**
+
+If present, the `lib` property specifies a subdirectory that should be built
+into a library. If it isn't specified, then the default behaviour is for the
+"source" directory to be built into a library.
+
+For example, to build a library out of the contents of `./some/subdirectory`
+instead of the default `source` directory, use:
+
+```json
+  "lib": "./some/subdirectory"
+```
+
 ### `extraIncludes`
 **type: Array of String (paths relative to module root)**
 

--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -135,7 +135,6 @@ class CMakeGen(object):
     def checkStandardSourceDir(self, dirname, component):
         err = validate.sourceDirValidationError(dirname, component.getName())
         if err:
-            # !!! FIXME: ensure this warning is covered in tests: it was broken
             logger.warning(err)
 
     def _validateListedSubdirsExist(self, component):
@@ -210,7 +209,8 @@ class CMakeGen(object):
                         header_subdirs.append((f, sources))
                 elif (f in ('test',)) or \
                      (os.path.normpath(f) in lib_subdirs) or \
-                     (os.path.normpath(f) in bin_subdirs):
+                     (os.path.normpath(f) in bin_subdirs) and not \
+                     component.ignores(f):
                     # (if there aren't any source files then do nothing)
                     # !!! FIXME: ensure this warning is covered in tests, also
                     # this warning should probably only be emitted if the
@@ -225,7 +225,9 @@ class CMakeGen(object):
             # issue a warning if a differently cased or common misspelling of a
             # standard directory name was encountered:
             check_directory_name_cases = list(lib_subdirs.keys()) + list(bin_subdirs.keys()) + ['test', 'resource']
-            if f.lower() in check_directory_name_cases + ['src'] and not f in check_directory_name_cases:
+            if f.lower() in check_directory_name_cases + ['src'] and not \
+               f in check_directory_name_cases and not \
+               component.ignores(f):
                 self.checkStandardSourceDir(f, component)
 
         return {

--- a/yotta/lib/component.py
+++ b/yotta/lib/component.py
@@ -119,6 +119,14 @@ class Component(pack.Pack):
                     Component_Description_File
                 )
             )
+        if 'bin' in self.description and 'lib' in self.description:
+            self.error = 'Both "lib" and "bin" are specified in module.json: '+\
+                'only one is allowed. If this is an executable module, then '+\
+                'it should not specify a "lib" subdirectory, and if this is '+\
+                'a re-usable library module, it should not specify a "bin" '+\
+                'subdirectory'
+            self.description = None
+        # specified in the description
         self.installed_dependencies = False
         self.dependencies_failed = False
         self.is_test_dependency = test_dependency
@@ -649,14 +657,56 @@ class Component(pack.Pack):
 
     def getBinaries(self):
         ''' Return a dictionary of binaries to compile: {"dirname":"exename"},
-            this is used when automatically generating CMakeLists '''
+            this is used when automatically generating CMakeLists
+
+            Note that currently modules may define only a single executable
+            binary or library to be built by the automatic build system, by
+            specifying `"bin": "dir-to-be-built-into-binary"`, or `"lib":
+            "dir-to-be-built-into-library"`, and the bin/lib will always have
+            the same name as the module. The default behaviour if nothing is
+            specified is for the 'source' directory to be built into a library.
+
+            The module.json syntax may allow for other combinations in the
+            future (and callers of this function should not rely on it
+            returning only a single item). For example, a "bin": {"dirname":
+            "exename"} syntax might be supported, however currently more
+            complex builds must be controlled by custom CMakeLists.
+        '''
         # the module.json syntax is a subset of the package.json syntax: a
         # single string that defines the source directory to use to build an
         # executable with the same name as the component. This may be extended
         # to include the rest of the npm syntax in future (map of source-dir to
         # exe name).
         if 'bin' in self.description:
-            return {self.description['bin']: self.getName()}
+            return {os.path.normpath(self.description['bin']): self.getName()}
+        else:
+            return {}
+
+    def getLibs(self, explicit_only=False):
+        ''' Return a dictionary of libraries to compile: {"dirname":"libname"},
+            this is used when automatically generating CMakeLists.
+
+            If explicit_only is not set, then in the absence of both 'lib' and
+            'bin' sections in the module.json file, the "source" directory
+            will be returned.
+
+            Note that currently modules may define only a single executable
+            binary or library to be built by the automatic build system, by
+            specifying `"bin": "dir-to-be-built-into-binary"`, or `"lib":
+            "dir-to-be-built-into-library"`, and the bin/lib will always have
+            the same name as the module. The default behaviour if nothing is
+            specified is for the 'source' directory to be built into a library.
+
+            The module.json syntax may allow for other combinations in the
+            future (and callers of this function should not rely on it
+            returning only a single item). For example, a "bin": {"dirname":
+            "exename"} syntax might be supported, however currently more
+            complex builds must be controlled by custom CMakeLists.
+        '''
+        if 'lib' in self.description:
+            return {os.path.normpath(self.description['lib']): self.getName()}
+        elif 'bin' not in self.description and not explicit_only:
+            return {'source': self.getName()}
         else:
             return {}
 

--- a/yotta/lib/component.py
+++ b/yotta/lib/component.py
@@ -95,6 +95,7 @@ class Component(pack.Pack):
             dependencies have been installed) for each of the dependencies.
 
         '''
+        self.description = OrderedDict()
         logger.log(VVVERBOSE_DEBUG, "Component: " +  path +  ' installed_linked=' + str(installed_linked))
         warn_deprecated_filename = False
         if (not os.path.exists(os.path.join(path, Component_Description_File))) and \
@@ -125,7 +126,7 @@ class Component(pack.Pack):
                 'it should not specify a "lib" subdirectory, and if this is '+\
                 'a re-usable library module, it should not specify a "bin" '+\
                 'subdirectory'
-            self.description = {}
+            self.description = OrderedDict()
         # specified in the description
         self.installed_dependencies = False
         self.dependencies_failed = False

--- a/yotta/lib/component.py
+++ b/yotta/lib/component.py
@@ -125,7 +125,7 @@ class Component(pack.Pack):
                 'it should not specify a "lib" subdirectory, and if this is '+\
                 'a re-usable library module, it should not specify a "bin" '+\
                 'subdirectory'
-            self.description = None
+            self.description = {}
         # specified in the description
         self.installed_dependencies = False
         self.dependencies_failed = False

--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -124,7 +124,6 @@ def tryReadJSON(filename, schemaname):
     try:
         with open(filename, 'r') as jsonfile:
             r = ordered_json.load(filename)
-            have_errors = False
             if schemaname is not None:
                 with open(schemaname, 'r') as schema_file:
                     schema = json.load(schema_file)

--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -101,6 +101,9 @@
         "bin": {
             "$ref": "#/definitions/path"
         },
+        "lib": {
+            "$ref": "#/definitions/path"
+        },
         "dependencies": {
             "$ref": "#/definitions/dependencyMap"
         },
@@ -290,8 +293,19 @@
         }
     },
     "required": ["name", "version"],
-    "oneOf" : [
-        {"required": ["license"]},
-        {"required": ["licenses"]}
+    "allOf": [
+        {
+            "description": "Every module must declare a license.",
+            "oneOf" : [
+                {"required": ["license"]},
+                {"required": ["licenses"]}
+            ]
+        },
+        {
+            "description": "both 'bin' and 'lib' must not be defined: a module is either an executable or a re-usable library module",
+            "not" : {
+                "required": ["bin", "lib"]
+            }
+        }
     ]
 }

--- a/yotta/test/cli/test_build.py
+++ b/yotta/test/cli/test_build.py
@@ -190,6 +190,75 @@ int main(){ return 0; }
 '''
 }
 
+Test_Custom_Lib_Dir = {
+'module.json':'''{
+  "name": "test-custom-dir-lib",
+  "version": "1.0.0",
+  "description": "Module to test trivial lib compilation",
+  "license": "Apache-2.0",
+  "lib": "mylibdir"
+}''',
+'test-custom-dir-lib/lib.h': '''
+int foo();
+''',
+'mylibdir/lib.c':'''
+#warning "this message should be printed"
+#include "test-custom-dir-lib/lib.h"
+int foo(){ return 7; }
+'''
+}
+
+Test_Custom_Bin_Dir = {
+'module.json':'''{
+  "name": "test-custom-dir-bin",
+  "version": "1.0.0",
+  "description": "Module to test trivial exe compilation",
+  "license": "Apache-2.0",
+  "bin": "mybindir"
+}''',
+'mybindir/main.c':'''
+#warning "this message should be printed"
+int main(){ return 0; }
+'''
+}
+
+# expect an error message
+Test_Lib_And_Bin = {
+'module.json':'''{
+  "name": "test-custom-dir-lib",
+  "version": "1.0.0",
+  "description": "Module to test trivial lib compilation",
+  "license": "Apache-2.0",
+  "lib": "mylibdir",
+  "bin": "mylibdir"
+}''',
+'mylibdir/lib.c':'''
+int foo(){ return 7; }
+'''
+}
+
+# expect an error message
+Test_Lib_Nonexistent = {
+'module.json':'''{
+  "name": "test-custom-dir-lib",
+  "version": "1.0.0",
+  "description": "Module to test trivial lib compilation",
+  "license": "Apache-2.0",
+  "lib": "doesntexist"
+}'''
+}
+
+# expect an error message
+Test_Bin_Nonexistent = {
+'module.json':'''{
+  "name": "test-custom-dir-lib",
+  "version": "1.0.0",
+  "description": "Module to test trivial lib compilation",
+  "license": "Apache-2.0",
+  "bin": "doesntexist"
+}'''
+}
+
 
 class TestCLIBuild(unittest.TestCase):
     @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
@@ -292,6 +361,47 @@ class TestCLIBuild(unittest.TestCase):
         test_dir = util.writeTestFiles(Test_Ignore_Custom_Cmake, True)
         stdout = self.runCheckCommand(['--target', util.nativeTarget(), 'build'], test_dir)
         self.assertNotIn('should be ignored', stdout)
+        util.rmRf(test_dir)
+
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_customLibDir(self):
+        test_dir = util.writeTestFiles(Test_Custom_Lib_Dir, True)
+        stdout = self.runCheckCommand(['--target', util.nativeTarget(), 'build'], test_dir)
+        self.assertIn('this message should be printed', stdout)
+        util.rmRf(test_dir)
+
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_customBinDir(self):
+        test_dir = util.writeTestFiles(Test_Custom_Bin_Dir, True)
+        stdout = self.runCheckCommand(['--target', util.nativeTarget(), 'build'], test_dir)
+        self.assertIn('this message should be printed', stdout)
+        util.rmRf(test_dir)
+
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_libAndBinSpecified(self):
+        test_dir = util.writeTestFiles(Test_Lib_And_Bin)
+        stdout, stderr, statuscode = cli.run(['--target', util.nativeTarget(), 'build'], cwd=test_dir)
+        self.assertNotEqual(statuscode, 0)
+        self.assertIn('Both "lib" and "bin" are specified in module.json: only one is allowed', stdout+stderr)
+        util.rmRf(test_dir)
+
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_libNonExistent(self):
+        test_dir = util.writeTestFiles(Test_Lib_Nonexistent)
+        stdout, stderr, statuscode = cli.run(['--target', util.nativeTarget(), 'build'], cwd=test_dir)
+        self.assertIn('directory "doesntexist" doesn\'t exist', stdout+stderr)
+        # !!! FIXME: should this error be fatal?
+        # self.assertNotEqual(statuscode, 0)
+        util.rmRf(test_dir)
+
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_binNonExistent(self):
+        test_dir = util.writeTestFiles(Test_Bin_Nonexistent)
+        stdout, stderr, statuscode = cli.run(['--target', util.nativeTarget(), 'build'], cwd=test_dir)
+        self.assertIn('directory "doesntexist" doesn\'t exist', stdout+stderr)
+        # !!! FIXME: should this error be fatal?
+        # self.assertNotEqual(statuscode, 0)
+        print(stdout+stderr)
         util.rmRf(test_dir)
 
     def runCheckCommand(self, args, test_dir):


### PR DESCRIPTION
 * see #641 for why this is useful
 * update module.json schema
 * add tests for warnings & errors in case that both lib and bin are specified,
   or the specified directories do not exist
 * this change should be 100% backwards compatible
 * improve and restructure subdirectory listing in CMakeGen to support this,
   and add additional warnings when directories are empty

Before merging, this needs associated documentation updates.