### PR TITLE
Warn if the target has not been explicitly set.

### DIFF
--- a/yotta/install.py
+++ b/yotta/install.py
@@ -78,14 +78,25 @@ def checkPrintStatus(errors, components):
 
 
 def installDeps(args, current_component):
+    # settings, , load and save settings, internal
+    from yotta.lib import settings
+
     logging.debug('install deps for %s' % current_component)
     if not current_component:
         logging.debug(str(current_component.getError()))
         logging.error('The current directory does not contain a valid module.')
         return 1
-    if not args.target:
-        logging.error('No target has been set, use "yotta target" to set one.')
-        return 1
+    # warn if the target hasn't been explicitly specified when running a build:
+    # this is likely user-error
+    if not settings.getProperty('build', 'targetSetExplicitly') and not \
+        getattr(args, '_target_set_explicitly', False):
+        logging.warning(
+            'The build target has not been set, so the default (%s) is being ' +
+            'used. You can use `yotta target <targetname>` to set the build ' +
+            'target. See http://yottadocs.mbed.com/tutorial/targets.html for '
+            'more information on using targets.',
+            args.target
+        )
     target, errors = current_component.satisfyTarget(args.target, additional_config=args.config)
     if errors:
         for error in errors:

--- a/yotta/options/target.py
+++ b/yotta/options/target.py
@@ -17,6 +17,7 @@ class TargetAction(Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values[0])
+        setattr(namespace, '_target_set_explicitly', True)
 
 def addTo(parser):
     parser.add_argument('-t', '--target', dest='target',

--- a/yotta/target.py
+++ b/yotta/target.py
@@ -123,6 +123,7 @@ def execCommand(args, following_args):
             else:
                 t = args.set_target
             settings.setProperty('build', 'target', t, not args.save_global)
+            settings.setProperty('build', 'targetSetExplicitly', True, not args.save_global)
             if not args.no_install:
                 # if we have a module in the current directory, try to make sure
                 # this target is installed


### PR DESCRIPTION
 * Fixes #645
 * Warnings are displayed by install (and thus build) subcommands