### PR TITLE
Test behaviour of "yotta target nonsuch" & fix error under python 3.

### DIFF
--- a/yotta/lib/access_common.py
+++ b/yotta/lib/access_common.py
@@ -58,7 +58,13 @@ class RemoteVersion(version.Version):
     def __repr__(self):
         return u'%s@%s from %s' % (self.name, self.friendly_version, self.friendly_source)
     def __str__(self):
-        return self.__unicode__()
+        import sys
+        # in python 3 __str__ must return a string (i.e. unicode), in
+        # python 2, it must not return unicode, so:
+        if sys.version_info[0] >= 3:
+            return self.__unicode__()
+        else:
+            return self.__unicode__().encode('utf8')
     def __unicode__(self):
         return self.__repr__()
 

--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -115,7 +115,13 @@ class DependencySpec(object):
     def __unicode__(self):
         return u'%s at %s' % (self.name, self.version_req)
     def __str__(self):
-        return self.__unicode__().encode('utf-8')
+        import sys
+        # in python 3 __str__ must return a string (i.e. unicode), in
+        # python 2, it must not return unicode, so:
+        if sys.version_info[0] >= 3:
+            return self.__unicode__()
+        else:
+            return self.__unicode__().encode('utf8')
     def __repr__(self):
         return self.__unicode__()
 

--- a/yotta/target.py
+++ b/yotta/target.py
@@ -134,4 +134,5 @@ def execCommand(args, following_args):
                         logging.error(err)
                     if len(errors):
                         logging.error('NOTE: use "yotta link-target" to test a locally modified target prior to publishing.')
+                        return 1
             return 0

--- a/yotta/test/cli/test_target.py
+++ b/yotta/test/cli/test_target.py
@@ -73,6 +73,12 @@ class TestCLITarget(unittest.TestCase):
                 os.stat(os.path.join(self.test_dir, '.yotta.json')).st_mode & Check_Not_Stat
             )
 
+    def test_setNonexistentTarget(self):
+        stdout, stderr, statuscode = cli.run(['target', 'thisdoesnotexist'], cwd=self.test_dir)
+        self.assertNotEqual(statuscode, 0)
+        self.assertNotIn('Exception', stdout+stderr)
+        self.assertIn('does not exist in the targets registry', stdout+stderr)
+
     def runCheckCommand(self, args):
         stdout, stderr, statuscode = cli.run(args, cwd=self.test_dir)
         self.assertEqual(statuscode, 0)


### PR DESCRIPTION
 * also ensure that the status returned by "yotta target nonsuch" is nonzero
 * the error reported should be friendly, and not an Exception backtrace, I've
   been unable to reproduce the reported exception locally, pushing this so the
   CI will check for it

This tests the behaviour reported in #647 