### PR TITLE
Fix test hanging issue

### DIFF
--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -683,8 +683,6 @@ class DerivedTarget(Target):
                 logger.debug('waiting for filter process')
                 test_filter.communicate()
                 logger.debug('reading test child stdout')
-                trailing_output = test_child.stdout.read()
-                logger.debug('test child trailing output: "%s"', trailing_output)
                 if test_child.poll() is None:
                     logger.warning('test child has not exited and will be terminated')
                     _tryTerminate(test_child)


### PR DESCRIPTION
If you run `yotta test` inside of a yotta module (testing with mbed-drivers), it will get through the first test and hang with the following output:

```
[...]
{{success}}
{{end}}
mbedgt: mbed-host-test-runner: stopped
mbedgt: mbed-host-test-runner: returned 'OK'
Completed in 9.12 sec
debug:target: reading test child stdout
```

I tracked the issue to the two lines of code that I removed in this PR. Not sure if there is a more appropriate fix for this, but the two lines in question seemed to just provide some debug info. The call to `read()` was the blocking issue.