### PR TITLE
add vcs description to build info header

### DIFF
--- a/docs/reference/buildsystem.md
+++ b/docs/reference/buildsystem.md
@@ -65,6 +65,7 @@ built, then the following will also be defined in this header:
 ```C
 #define YOTTA_BUILD_VCS_ID 0123456789abcdef // git or mercurial hash, variable length up to 40 characters
 #define YOTTA_BUILD_VCS_CLEAN 1             // 1 if there were no uncommitted changes, else 0
+#define YOTTA_BUILD_VCS_DESCRIPTION v0.5-57-gad36348 // git describe or mercurial equivalent
 ```
 
 Corresponding definitions for all of the build information are always available

--- a/yotta/lib/cmakegen.py
+++ b/yotta/lib/cmakegen.py
@@ -364,9 +364,11 @@ class CMakeGen(object):
                 )
             if commit_id is not None:
                 clean_state = int(vcs_instance.isClean())
+                description = vcs_instance.getDescription()
                 definitions += [
                     ('YOTTA_BUILD_VCS_ID',    commit_id,   'git or mercurial hash'),
-                    ('YOTTA_BUILD_VCS_CLEAN', clean_state, 'evaluates true if the version control system was clean, otherwise false')
+                    ('YOTTA_BUILD_VCS_CLEAN', clean_state, 'evaluates true if the version control system was clean, otherwise false'),
+                    ('YOTTA_BUILD_VCS_DESCRIPTION', description, 'git describe or mercurial equivalent')
                 ]
 
         for d in definitions:

--- a/yotta/lib/vcs.py
+++ b/yotta/lib/vcs.py
@@ -43,6 +43,8 @@ class VCS(object):
         raise NotImplementedError()
     def getCommitId(self):
         raise NotImplementedError()
+    def getDescription(self):
+        raise NotImplementedError()
     def __nonzero__(self):
         raise NotImplementedError()
     # python 3 truthiness
@@ -110,6 +112,10 @@ class Git(VCS):
 
     def getCommitId(self):
         out, err = self._execCommands([self._gitCmd('rev-parse', 'HEAD')])
+        return out.strip()
+
+    def getDescription(self):
+        out, err = self._execCommands([self._gitCmd('describe', '--always', '--tags')])
         return out.strip()
 
     def workingDirectory(self):
@@ -239,6 +245,9 @@ class HG(VCS):
 
     def getCommitId(self):
         return self.repo.hg_node()
+
+    def getDescription(self):
+        return self.repo.hg_command('log', '-r', '.', '-T', "{latesttag}{sub('^-0-.*', '', '-{latesttagdistance}-m{node|short}')}")
 
     def workingDirectory(self):
         return self.worktree

--- a/yotta/lib/vcs.py
+++ b/yotta/lib/vcs.py
@@ -247,7 +247,10 @@ class HG(VCS):
         return self.repo.hg_node()
 
     def getDescription(self):
-        return self.repo.hg_command('log', '--rev', '.', '--template', "{latesttag}{sub('^-0-.*', '', '-{latesttagdistance}-m{node|short}')}")
+        try:
+            return self.repo.hg_command('log', '--rev', '.', '--template', "{latesttag}{sub('^-0-.*', '', '-{latesttagdistance}-m{node|short}')}")
+        except self.hgapi.HgException: # old mercurial doesn't support above command, output short hash, m-prefixed
+            return "m" + self.getCommitId()[:12]
 
     def workingDirectory(self):
         return self.worktree

--- a/yotta/lib/vcs.py
+++ b/yotta/lib/vcs.py
@@ -247,7 +247,7 @@ class HG(VCS):
         return self.repo.hg_node()
 
     def getDescription(self):
-        return self.repo.hg_command('log', '-r', '.', '-T', "{latesttag}{sub('^-0-.*', '', '-{latesttagdistance}-m{node|short}')}")
+        return self.repo.hg_command('log', '--rev', '.', '--template', "{latesttag}{sub('^-0-.*', '', '-{latesttagdistance}-m{node|short}')}")
 
     def workingDirectory(self):
         return self.worktree

--- a/yotta/test/test_vcs.py
+++ b/yotta/test/test_vcs.py
@@ -39,6 +39,10 @@ class TestGit(unittest.TestCase):
         commit_id = self.working_copy.getCommitId()
         self.assertTrue(len(commit_id) >= 6)
 
+    def test_getDescription(self):
+        description = self.working_copy.getDescription()
+        self.assertTrue(len(description) >= 1)
+
     def test_isClean(self):
         self.assertTrue(self.working_copy.isClean())
         fsutils.rmF(os.path.join(self.working_copy.workingDirectory(), 'module.json'))
@@ -72,6 +76,10 @@ class TestHg(unittest.TestCase):
     def test_getCommitId(self):
         commit_id = self.working_copy.getCommitId()
         self.assertTrue(len(commit_id) >= 6)
+
+    def test_getDescription(self):
+        description = self.working_copy.getDescription()
+        self.assertTrue(len(description) >= 1)
 
     def test_isClean(self):
         self.assertTrue(self.working_copy.isClean())


### PR DESCRIPTION
git describe is quite useful to get a revision info based on the vcs
which also honors tags. so let's put this info in a new define into the
build info header.
for git 'git describe --always --tags' is used, for mercurial a somewhat
equivalent found at [1] as mercurial itself doesn't provide a describe
subcommand.
doc has been updated accordingly.
the units test unly checks for a description string longer than 1

[1] http://stackoverflow.com/questions/6693209/is-there-an-equivalent-
to-gits-describe-function-for-mercurial

Signed-off-by: Martin Gysel <me@bearsh.org>