### PR TITLE
Potential fix for #727

### DIFF
--- a/yotta/search.py
+++ b/yotta/search.py
@@ -125,7 +125,11 @@ def execCommand(args, following_args):
     for result in itertools.islice(registry_access.search(query=args.query, keywords=args.kw, registry=args.registry), args.limit):
         success= True
         if args.type == 'both' or args.type == result['type']:
-            print(formatResult(result, args.plain, short=args.short))
+            fmt = formatResult(result, args.plain, short=args.short)
+            try:
+                print(fmt)
+            except UnicodeEncodeError:
+                print(fmt.encode('ascii', 'ignore'))
     for repo in filter(lambda s: 'type' in s and s['type'] == 'registry', settings.get('sources') or []) :
         count = 0
         print('')


### PR DESCRIPTION
While #727 is not technically yotta's fault, it can be quite an annoying
issue for anything that tries to redirect yotta's output. This patch
attempts a simple fix for that by performing a dumb Unicode to ASCII
translation everytime an UnicodeEncodeError is raised.