### PR TITLE
Scripting/hooks support

### DIFF
--- a/docs/reference/module.md
+++ b/docs/reference/module.md
@@ -36,7 +36,7 @@ use `yotta init` to populate the file by answering a sequence of questions.
 
 ## Properties
 
-### `name` *required*
+### <a href="name" name="name">#</a> `name` *required*
 **type: String**
 
 The unique name of your module. It's got to be globally unique, so be
@@ -47,7 +47,7 @@ a letter. (This reduces problems with case insensitive filesystems, and
 confusingly similar names.)
 
 
-### `version` *required*
+### <a href="version" name="version">#</a> `version` *required*
 **type: String (conforming to the [semver](http://semver.org) specification)**
 
 yotta uses Semantic Versions for modules: your module's version lets people who
@@ -84,7 +84,7 @@ For `1+.x.x` versions, semantic versioning defines the following rules:
 For a complete guide to semantic versioning, see [semver.org](http://semver.org).
 
 
-### `licenses` *deprecated*
+### <a href="licenses" name="licenses">#</a> `licenses` *deprecated*
 See also: [`license`](#license). The `licenses` property was formerly a method
 of specifying that multiple licenses applied to a module. It's now preferred to
 use a single `license` field containing a SPDX license expression.
@@ -100,8 +100,7 @@ use a single `license` field containing a SPDX license expression.
   ],
 ```
 
-<a name="license"></a>
-### `license` *required*
+### <a href="license" name="license">#</a> `license` *required*
 **type: String** `"<SPDX license identifier>"`**
 
 The license property in module.json should include all of the licenses that
@@ -133,8 +132,7 @@ licenses, and automatically fill in the license field for those options.
 **Remember: some people will find it much harder to use your module if you
 don't use a standard permissive license.**
 
-<a name="dependencies"></a>
-### `dependencies`
+### <a href="#dependencies" name="dependencies">#</a>`dependencies`
 **type: Object `{"<modulename>": "<version specification or source>"}`**
 
 While not required (since your module may not depend on anything), the
@@ -227,8 +225,7 @@ Where <version specification> is a tag with a semantic version identifier.
 **Note that modules depending on github, ssh, or hg repositories cannot be
 published: they will be rejected by the yotta registry.**
 
-<a name="targetDependencies"></a>
-### `targetDependencies`
+### <a href="targetDependencies" name="targetDependencies">#</a> `targetDependencies`
 **type: Object `{"<target-identifier>": <dependencies object>}`**
 
 The modules in the `dependencies` property are always installed and used, no
@@ -284,8 +281,7 @@ Example:
 	}
 ```
 
-<a name="testDependencies"></a>
-### `testDependencies`
+### <a href="#testDependencies" name="testDependencies">#</a> `testDependencies`
 **type: Object `{"<modulename>": "<version specification or source>"}`**
 
 The `testDependencies` section can be used to list modules that are only
@@ -296,24 +292,24 @@ See [`dependencies`](#dependencies) for a description of how to specify
 different sorts of dependencies.
 
 
-### `description`
+### <a href="#description" name="description">#</a> `description`
 **type: String**
 
 Brief of what your module does. This helps other people to find your module.
 Include a `readme.md` file with a longer description, API documentation and
 example code.
 
-### `keywords`
+### <a href="#keywords" name="keywords">#</a>`keywords`
 **type: Array of String**
 
 Keywords describe what your module does, and help other people to find it.
 
-### `homepage`
+### <a href="#homepage" name="homepage">#</a>`homepage`
 **type: String (url)**
 
 The URL of your module's homepage (if any).
 
-### `repository`
+### <a href="#repository" name="repository">#</a>`repository`
 **type: Object `{"url":"<url>", "type": "<git, hg, or svn>"}`**
 
 The `repository` section helps other people to contribute to your module by
@@ -329,14 +325,14 @@ on modules from source control repositories, instead of from the public modules
 registry.
 
 
-### `private`
+### <a href="#private" name="private">#</a> `private`
 **type: Boolean**
 
 If present, and set to `true`, then `yotta publish` will not allow you to
 publish this module to the public registry. This is useful to prevent
 accidental publication of private modules and applications.
 
-### `bugs`
+### <a href="#bugs" name="bugs">#</a> `bugs`
 **type: Object `{"url":"<url>", "email": "<optional email>"}`**
 
 Including a bugs section helps people who use your module to report problems,
@@ -352,7 +348,7 @@ Example:
 ```
 
 
-### `bin`
+### <a href="#bin" name="bin">#</a> `bin`
 **type: String (path relative to module root)**
 
 If present, the `bin` property specifies a subdirectory that should be built
@@ -365,7 +361,7 @@ of the contents of the source directory, set:
   "bin": "./source"
 ```
 
-### `lib`
+### <a href="#lib" name="lib">#</a> `lib`
 **type: String (path relative to module root)**
 
 If present, the `lib` property specifies a subdirectory that should be built
@@ -379,7 +375,7 @@ instead of the default `source` directory, use:
   "lib": "./some/subdirectory"
 ```
 
-### `extraIncludes`
+### <a href="#extraIncludes" name="extraIncludes">#</a> `extraIncludes`
 **type: Array of String (paths relative to module root)**
 
 **WARNING** do not use this property in released modules. It exists only to
@@ -401,22 +397,60 @@ included as:
 eliminates any possibility of header name collision, as published module names
 are forced to be unique by the yotta module registry.
 
-<a name="scripts"></a>
-### `scripts`
+### <a href="#scripts" name="scripts">#</a> `scripts`
 **type: hash of script-name to command**
 
-Each command is an array of the separate command arguments.
+Each command is either an array of the separate command arguments, or a single
+string which yotta will split into parts based on normal shell command
+splitting rules.
+
+Any script which is a `.py` file will be invoked using the python interpreter
+which is running yotta.
 
 The supported scripts are:
 
- * **testReporter**: this command is run for the tests of each module, and is
+ * **`preVersion`**: Runs before the [`yotta
+   version`](/reference/commands.html#yotta-version)
+   command increments the version number. The old and new version numbers are
+   available as environment variables `YOTTA_OLD_VERSION` and
+   `YOTTA_NEW_VERSION`.  Can return non-zero to prevent continuing.
+ * **`postVersion`**: Runs after the version has been bumped by `yotta
+   version`, but before any changes have been committed or tagged in VCS
+   (returning non-zero will prevent
+   anything from being committed).
+ * **`prePublish`**: Runs before the module is
+   [published](/reference/commands.html#yotta-publish). Can return non-zero to
+   prevent publishing.
+ * **`postPublish`**: Runs after the module has been published. Tweet here.
+ * **`postInstall`**: Runs once after a module is downloaded into
+   `yotta_modules`, or downloaded as a top-level module.
+ * **`preGenerate`**: Runs before generating CMake for any build including this
+   module.
+ * **`preBuild`**: Runs immediately before each build including this module.
+ * **`postBuild`**: Runs after everything has been built. This script will be
+   run whether or not this module was actually re-built (so don't do slow
+   things here!): consider using a .cmake file to define post-build rules
+   instead.
+ * **`preTest`**: Runs before tests from this module are loaded by the target's
+   scripts.test script.
+ * **`preDebug`**: Runs before this module (if it is an application), or one of
+   its tests is loaded by the target's scripts.debug script.
+ * **`preStart`**: Runs before this module (if it is an application) is loaded
+   by the target's scripts.start script.
+ * **`testReporter`**: this command is run for the tests of each module, and is
    piped the output of the tests. It may display information about the
    success/failure of a test, and should exit with a status 0 if the test
    passed, or a status 1 if the test failed.
+ 
+The `preGenerate`, `preBuild` and `postBuild` scripts have the merged [config
+information](/reference/config.html) available to them in a file indicated by the
+`YOTTA_MERGED_CONFIG_FILE` environment variable.
 
-For example, the scripts for a module that uses the
-[greentea](https://github.com/ARMmbed/greentea) test framework, would use the
-`greentea` helper program to parse and verify the test output:
+#### Examples
+
+A module that uses the [greentea](https://github.com/ARMmbed/greentea) test
+framework, would use the `greentea` helper program to parse and verify the test
+output might use this testReporter script:
 
 ```json
    "scripts": {
@@ -424,8 +458,8 @@ For example, the scripts for a module that uses the
    }
 ```
 
-<a name="yotta"></a>
-### `yotta`
+
+### <a href="#yotta" name="yotta">#</a>  `yotta`
 **type: version specification**
 
 A version specification for the version of yotta that this module requires. For

--- a/docs/reference/target.md
+++ b/docs/reference/target.md
@@ -178,24 +178,51 @@ included cmake files as `YOTTA_MODULE_NAME`.
 ### <a href="#scripts" name="scripts">#</a> `scripts`
 **type: hash of script-name to command**
 
-Each command is an array of the separate command arguments.
+Each command is either an array of the separate command arguments, or a single
+string which yotta will split into parts based on normal shell command
+splitting rules.
+
+In all cases any instances of `$program` in the command text will be replaced
+with the path to yotta-compiled program about to be launched/debugged. The path
+to the program is also available to commands as the `YOTTA_PROGRAM` environment
+variable.
+
+Any script which is a `.py` file will be invoked using the python interpreter
+which is running yotta.
 
 The supported scripts are:
 
- * **debug**: this is the command that's run by `yotta debug`, it should
-   probably open a debugger. `$program` will be expanded to the full path of
-   the binary to be debugged.
- * **test**: this command is used by `yotta test` to run each test. `$program`
-   will be expanded to the full path of the binary to be debugged. For
+ * **`debug`**: this is the command that's run by `yotta debug`, it should
+   probably open a debugger.
+ * **`test`**: this command is used by `yotta test` to run each test. For
    cross-compiling targets, this command should load the binary on to the
    target device, and then print the program's output on standard out.
+ * **`start`**: this command is used by `yotta start` to start an executable. For
+   cross-compiling targets, this command should load the binary onto the target
+   device, and launch it.
+ * **`preVersion`**: Runs before the [`yotta
+   version`](/reference/commands.html#yotta-version)
+   command increments the version number. The old and new version numbers are
+   available as environment variables `YOTTA_OLD_VERSION` and
+   `YOTTA_NEW_VERSION`.  Can return non-zero to prevent continuing.
+ * **`postVersion`**: Runs after the version has been bumped by `yotta
+   version`, but before any changes have been committed or tagged in VCS
+   (returning non-zero will prevent
+   anything from being committed).
+ * **`prePublish`**: Runs before the target is
+   [published](/reference/commands.html#yotta-publish). Can return non-zero to
+   prevent publishing.
+ * **`postPublish`**: Runs after the target has been published. Tweet here.
+ * **`postInstall`**: Runs once after a target is downloaded into
+   `yotta_targets`.
 
-For example, the scripts for a native compilation target might look like:
+### Examples
+
+To use lldb as the debugger, a target for native compilation would define:
 
 ```json
    "scripts": {
       "debug": ["lldb", "$program"],
-      "test": ["$program"]
    }
 ```
 

--- a/yotta/debug.py
+++ b/yotta/debug.py
@@ -44,7 +44,10 @@ def execCommand(args, following_args):
             logging.error('This module describes a library not an executable, so you must name an executable to debug.')
             return 1
 
-    errcode = None
+    errcode = c.runScript('preDebug', {"YOTTA_PROGRAM":args.program})
+    if errcode:
+        return errcode
+
     error = target.debug(builddir, args.program)
     if error:
         logging.error(error)

--- a/yotta/debug.py
+++ b/yotta/debug.py
@@ -15,7 +15,7 @@ from yotta import options
 
 def addOptions(parser):
     options.config.addTo(parser)
-    parser.add_argument('program', default=None,
+    parser.add_argument('program', default=None, nargs='?',
         help='name of the program to be debugged'
     )
 
@@ -35,8 +35,15 @@ def execCommand(args, following_args):
 
     builddir = os.path.join(cwd, 'build', target.getName())
 
-    # !!! FIXME: the program should be specified by the description of the
-    # current project (or a default value for the program should)
+    if args.program is None:
+        if c.isApplication():
+            # if no program was specified, default to the name of the executable
+            # module (if this is an executable module)
+            args.program = c.getName()
+        else:
+            logging.error('This module describes a library not an executable, so you must name an executable to debug.')
+            return 1
+
     errcode = None
     error = target.debug(builddir, args.program)
     if error:

--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -335,6 +335,10 @@ def _satisfyVersionByInstallingVersion(name, version_required, working_directory
         raise Exception('%s %s (specification %s) has incorrect name %s' % (
             type, name, version_required, r.getName()
         ))
+    # error code deliberately ignored here for now, it isn't clear what the
+    # behaviour should be (abort? remove the unpacked state then abort?
+    # continue?)
+    r.runScript('postInstall')
     return r
 
 def satisfyVersion(

--- a/yotta/lib/component.py
+++ b/yotta/lib/component.py
@@ -832,11 +832,3 @@ class Component(pack.Pack):
             return False
         del self.description['dependencies'][component]
         return True
-
-    def getTestFilterCommand(self):
-        ''' return the test-output filtering command (array of strings) that
-            this module defines, if any. '''
-        if 'scripts' in self.description and 'testReporter' in self.description['scripts']:
-            return self.description['scripts']['testReporter']
-        else:
-            return None

--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -510,8 +510,15 @@ class Pack(object):
                 import shlex
                 script = shlex.split(script)
             # if the command is a python script, run it with the python
-            # interpreter being used to run yotta:
+            # interpreter being used to run yotta, also fetch the absolute path
+            # to the script relative to this module (so that the script can be
+            # distributed with the module, no matter what current working
+            # directory it will be executed in):
             if len(script) and script[0].lower().endswith('.py'):
+                if not os.path.isabs(script[0]):
+                    absscript = os.path.abspath(os.path.join(self.path, script[0]))
+                    logger.debug('rewriting script %s to be absolute path %s', script[0], absscript)
+                    script[0] = absscript
                 import sys
                 script = [sys.executable] + script
 

--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -87,6 +87,43 @@
             "type": "object",
             "patternProperties": {
                 "^(testReporter)$": {
+                    "comment": "A script to be used to process test results.",
+                    "$ref": "#/definitions/command"
+                },
+                "prePublish": {
+                    "comment": "Runs before a module is published. Return non-zero to prevent publishing.",
+                    "$ref": "#/definitions/command"
+                },
+                "postPublish": {
+                    "comment": "Runs after a module has been published. Put your twitter posting script here.",
+                    "$ref": "#/definitions/command"
+                },
+                "postInstall": {
+                    "comment": "Runs once after a module is downloaded into yotta_modules.",
+                    "$ref": "#/definitions/command"
+                },
+                "preConfig": {
+                    "comment": "Runs at the start of the build step, before yotta writes anything on disk (but after the module.json file has been read).",
+                    "$ref": "#/definitions/command"
+                },
+                "preGenerate": {
+                    "comment": "Runs before generating CMake for the build. The merged config info is available in a file indicated by the YOTTA_MERGED_CONFIG_FILE environment variable.",
+                    "$ref": "#/definitions/command"
+                },
+                "preBuild": {
+                    "comment": "Runs immediately before each build. The merged config info is available in a file indicated by the YOTTA_MERGED_CONFIG_FILE environment variable.",
+                    "$ref": "#/definitions/command"
+                },
+                "preTest": {
+                    "comment": "Runs before tests from this module are loaded by the target's scripts.test script",
+                    "$ref": "#/definitions/command"
+                },
+                "preDebug": {
+                    "comment": "Runs before any application including this module is loaded by the target's scripts.debug script",
+                    "$ref": "#/definitions/command"
+                },
+                "preStart": {
+                    "comment": "Runs before any application including this module is loaded by the target's scripts.start script",
                     "$ref": "#/definitions/command"
                 }
             },

--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -110,6 +110,10 @@
                     "comment": "Runs immediately before each build. The merged config info is available in a file indicated by the YOTTA_MERGED_CONFIG_FILE environment variable.",
                     "$ref": "#/definitions/command"
                 },
+                "postBuild": {
+                    "comment": "Runs after everything has been built. This script will be run whether or not this module was actually re-built (so don't do slow things here!): consider using a .cmake file to define post-build rules instead. The merged config info is available in a file indicated by the YOTTA_MERGED_CONFIG_FILE environment variable.",
+                    "$ref": "#/definitions/command"
+                },
                 "preTest": {
                     "comment": "Runs before tests from this module are loaded by the target's scripts.test script",
                     "$ref": "#/definitions/command"

--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -90,40 +90,47 @@
                     "comment": "A script to be used to process test results.",
                     "$ref": "#/definitions/command"
                 },
-                "prePublish": {
-                    "comment": "Runs before a this module is published. Return non-zero to prevent publishing.",
+                "^prePublish$": {
+                    "comment": "Runs before this module is published. Return non-zero to prevent publishing.",
                     "$ref": "#/definitions/command"
                 },
-                "postPublish": {
+                "^postPublish$": {
                     "comment": "Runs after this module has been published. Put your twitter posting script here.",
                     "$ref": "#/definitions/command"
                 },
-                "postInstall": {
+                "^postInstall$": {
                     "comment": "Runs once after a module is downloaded into yotta_modules, or downloaded as a top-level module.",
                     "$ref": "#/definitions/command"
                 },
-                "preGenerate": {
+                "^preVersion$": {
+                    "comment": "Runs before the yotta version command increments the version number, the new and old version numbers are available as environment variables: YOTTA_NEW_VERSION and YOTTA_OLD_VERSION. Return non-zero to prevent continuing.",
+                    "$ref": "#/definitions/command"
+                },
+                "^postVersion$": {
+                    "comment": "Runs after the yotta version command has incremented the version number (but BEFORE anything is tagged or committed to git/hg). Return non-zero to prevent continuing.",
+                    "$ref": "#/definitions/command"
+                },
+                "^preGenerate$": {
                     "comment": "Runs before generating CMake for the build. The merged config info is available in a file indicated by the YOTTA_MERGED_CONFIG_FILE environment variable.",
                     "$ref": "#/definitions/command"
                 },
-                "preBuild": {
+                "^preBuild$": {
                     "comment": "Runs immediately before each build. The merged config info is available in a file indicated by the YOTTA_MERGED_CONFIG_FILE environment variable.",
                     "$ref": "#/definitions/command"
                 },
-                "postBuild": {
+                "^postBuild$": {
                     "comment": "Runs after everything has been built. This script will be run whether or not this module was actually re-built (so don't do slow things here!): consider using a .cmake file to define post-build rules instead. The merged config info is available in a file indicated by the YOTTA_MERGED_CONFIG_FILE environment variable.",
                     "$ref": "#/definitions/command"
                 },
-                "preTest": {
-                    "comment": "Runs before tests from this module are loaded by the target's scripts.test script",
+                "^preTest$": {
+                    "comment": "Runs before tests from this module are loaded by the target's scripts.test script", "$ref": "#/definitions/command"
+                },
+                "^preDebug$": {
+                    "comment": "Runs before this module (if it is an application), or one of its tests is loaded by the target's scripts.debug script.",
                     "$ref": "#/definitions/command"
                 },
-                "preDebug": {
-                    "comment": "Runs before any application including this module is loaded by the target's scripts.debug script",
-                    "$ref": "#/definitions/command"
-                },
-                "preStart": {
-                    "comment": "Runs before any application including this module is loaded by the target's scripts.start script",
+                "^preStart$": {
+                    "comment": "Runs before this module (if it is an application) is loaded by the target's scripts.start script.",
                     "$ref": "#/definitions/command"
                 }
             },

--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -91,11 +91,11 @@
                     "$ref": "#/definitions/command"
                 },
                 "prePublish": {
-                    "comment": "Runs before a module is published. Return non-zero to prevent publishing.",
+                    "comment": "Runs before a this module is published. Return non-zero to prevent publishing.",
                     "$ref": "#/definitions/command"
                 },
                 "postPublish": {
-                    "comment": "Runs after a module has been published. Put your twitter posting script here.",
+                    "comment": "Runs after this module has been published. Put your twitter posting script here.",
                     "$ref": "#/definitions/command"
                 },
                 "postInstall": {

--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -99,7 +99,7 @@
                     "$ref": "#/definitions/command"
                 },
                 "postInstall": {
-                    "comment": "Runs once after a module is downloaded into yotta_modules.",
+                    "comment": "Runs once after a module is downloaded into yotta_modules, or downloaded as a top-level module.",
                     "$ref": "#/definitions/command"
                 },
                 "preConfig": {

--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -102,10 +102,6 @@
                     "comment": "Runs once after a module is downloaded into yotta_modules, or downloaded as a top-level module.",
                     "$ref": "#/definitions/command"
                 },
-                "preConfig": {
-                    "comment": "Runs at the start of the build step, before yotta writes anything on disk (but after the module.json file has been read).",
-                    "$ref": "#/definitions/command"
-                },
                 "preGenerate": {
                     "comment": "Runs before generating CMake for the build. The merged config info is available in a file indicated by the YOTTA_MERGED_CONFIG_FILE environment variable.",
                     "$ref": "#/definitions/command"

--- a/yotta/lib/schema/module.json
+++ b/yotta/lib/schema/module.json
@@ -325,12 +325,22 @@
             "pattern": ".*"
         },
         "command":{
-            "type": "array",
-            "items": {
-                "type": "string",
-                "minLength": 0,
-                "maxLength": 3000
-            }
+            "comment": "a command is either an array of parts, or a single string (which will be split into parts according to normal shell splitting rules)",
+            "oneOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 0,
+                        "maxLength": 3000
+                    }
+                },
+                {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 3000
+                }
+            ]
         }
     },
     "required": ["name", "version"],

--- a/yotta/lib/schema/target.json
+++ b/yotta/lib/schema/target.json
@@ -310,13 +310,23 @@
                "type": "string",
             "pattern": ".*"
         },
-        "command":{
-            "type": "array",
-            "items": {
-                "type": "string",
-                "minLength": 0,
-                "maxLength": 3000
-            }
+        "command": {
+            "comment": "a command is either an array of parts, or a single string (which will be split into parts according to normal shell splitting rules)",
+            "oneOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 0,
+                        "maxLength": 3000
+                    }
+                },
+                {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 3000
+                }
+            ]
         },
         "configValues":{
             "oneOf": [ 

--- a/yotta/lib/schema/target.json
+++ b/yotta/lib/schema/target.json
@@ -99,6 +99,26 @@
         "scripts": {
             "type": "object",
             "patternProperties": {
+                "^prePublish$": {
+                    "comment": "Runs before this module is published. Return non-zero to prevent publishing.",
+                    "$ref": "#/definitions/command"
+                },
+                "^postPublish$": {
+                    "comment": "Runs after this module has been published. Put your twitter posting script here.",
+                    "$ref": "#/definitions/command"
+                },
+                "^postInstall$": {
+                    "comment": "Runs once after a module is downloaded into yotta_modules, or downloaded as a top-level module.",
+                    "$ref": "#/definitions/command"
+                },
+                "^preVersion$": {
+                    "comment": "Runs before the yotta version command increments the version number. Return non-zero to prevent continuing.",
+                    "$ref": "#/definitions/command"
+                },
+                "^postVersion$": {
+                    "comment": "Runs after the yotta version command has incremented the version number (but BEFORE anything is tagged or committed to git/hg). Return non-zero to prevent continuing.",
+                    "$ref": "#/definitions/command"
+                },
                 "^debug$": {
                     "comment": "script used to load programs for debugging. The program to be loaded is expanded from $program or available as environment varianble YOTTA_PROGRAM",
                     "$ref": "#/definitions/command"

--- a/yotta/lib/schema/target.json
+++ b/yotta/lib/schema/target.json
@@ -99,7 +99,16 @@
         "scripts": {
             "type": "object",
             "patternProperties": {
-                "^(debug|test)$": {
+                "^debug$": {
+                    "comment": "script used to load programs for debugging. The program to be loaded is expanded from $program or available as environment varianble YOTTA_PROGRAM",
+                    "$ref": "#/definitions/command"
+                },
+                "^test$": {
+                    "comment": "script used to run programs for testing. The program to be loaded is expanded from $program or available as environment varianble YOTTA_PROGRAM",
+                    "$ref": "#/definitions/command"
+                },
+                "^start$": {
+                    "comment": "script used to start an application. The program to be loaded is expanded from $program or available as environment varianble YOTTA_PROGRAM",
                     "$ref": "#/definitions/command"
                 }
             },

--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -293,8 +293,9 @@ class DerivedTarget(Target):
             a base target)
         '''
         for t in self.hierarchy:
-            if 'scripts' in t.description and scriptname in t.description['scripts']:
-                return t.description['scripts'][scriptname]
+            s = t.getScript(scriptname)
+            if s:
+                return s
         return None
 
     def _loadConfig(self):
@@ -745,6 +746,17 @@ class DerivedTarget(Target):
                 os.path.expandvars(string.Template(x).safe_substitute(program=os.path.abspath(os.path.join(test_dir, test_command))))
                 for x in test_script
             ] + forward_args
+
+        # if the command is a python script, run it with the python interpreter
+        # being used to run yotta:
+        if test_command[0].lower().endswith('.py'):
+            import sys
+            python_interpreter = sys.executable
+            cmd = [python_interpreter] + cmd
+        if filter_command and filter_command[0].lower().endswith('.py'):
+            import sys
+            python_interpreter = sys.executable
+            filter_command = [python_interpreter] + filter_command
 
         env = os.environ.copy()
         env['YOTTA_PROGRAM'] = test_command

--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -594,7 +594,7 @@ class DerivedTarget(Target):
 
             env = os.environ.copy()
             env['YOTTA_PROGRAM'] = prog_path
-            
+
             if self.getScript('start'):
                 cmd = [
                     os.path.expandvars(string.Template(x).safe_substitute(program=prog_path))

--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 from yotta.lib import ordered_json
 # Pack, , common parts of Components/Targets, internal
 from yotta.lib import pack
+from yotta.lib.pack import tryTerminate as _tryTerminate
 # fsutils, , misc filesystem utils, internal
 from yotta.lib import fsutils
 
@@ -50,15 +51,6 @@ def _mergeDictionaries(*args):
         elif isinstance(result[k], dict) and isinstance(v, dict):
             result[k] = _mergeDictionaries(result[k], v)
     return result
-
-def _tryTerminate(process):
-    try:
-        process.terminate()
-    except OSError as e:
-        # if the error is "no such process" then the process probably exited
-        # while we were waiting for it, so don't raise an exception
-        if e.errno != errno.ESRCH:
-            raise
 
 def _mirrorStructure(dictionary, value):
     ''' create a new nested dictionary object with the same structure as
@@ -588,7 +580,7 @@ class DerivedTarget(Target):
         logging.error('could not find program "%s" to debug' %  program)
         return None
 
-    #@fsutils.dropRootPrivs
+    @fsutils.dropRootPrivs
     def start(self, builddir, program, forward_args):
         ''' Launch the specified program. Uses the `start` script if specified
             by the target, attempts to run it natively if that script is not

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -133,7 +133,10 @@ def main():
         '"test" script that will be used to run each test. Modules may also '+
         'define a "testReporter" script, which will be piped the output from '+
         'each test, and may produce a summary.',
-        'Run the tests for the current module on the current target. Requires target support.'
+        'Run the tests for the current module on the current target. Requires target support for cross-compiling targets.'
+    )
+    addParser('start', 'start',
+        'Launch the compiled program (available for executable modules only). Requires target support for cross-compiling targets.'
     )
     addParser('publish', 'publish', 'Publish a module or target to the public registry.')
     addParser('unpublish', 'unpublish', 'Un-publish a recently published module or target.')
@@ -168,7 +171,8 @@ def main():
      'unlink-target':subparser.choices['remove'],
              'owner':subparser.choices['owners'],
               'lics':subparser.choices['licenses'],
-               'who':subparser.choices['whoami']
+               'who':subparser.choices['whoami'],
+               'run':subparser.choices['start']
     }
     subparser.choices.update(short_commands)
 

--- a/yotta/publish.py
+++ b/yotta/publish.py
@@ -65,13 +65,22 @@ def execCommand(args, following_args):
     if errcode and not args.force:
         return errcode
 
+    errcode = p.runScript('prePublish')
+    if errcode:
+        logging.error("prePublish script error code %s prevents publishing", errcode)
+        return errcode
+
     error = p.publish(args.registry)
     if error:
         logging.error(error)
         return 1
 
+    errcode = p.runScript('postPublish')
+    if errcode:
+        logging.warning("postPublish script exited with code %s", errcode)
+
     # tag the version published as 'latest'
     # !!! can't do this, as can't move tags in git?
     #p.commitVCS(tag='latest')
     logging.info('published latest version: %s', p.getVersion())
-    return 0
+    return errcode

--- a/yotta/start.py
+++ b/yotta/start.py
@@ -1,0 +1,55 @@
+# Copyright 2014-2016 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library modules, , ,
+import os
+import logging
+
+# validate, , validate things, internal
+from yotta.lib import validate
+# --config option, , , internal
+from yotta import options
+
+
+def addOptions(parser):
+    options.config.addTo(parser)
+    parser.add_argument('program', default=None, nargs='?',
+        help='name of the program to be started'
+    )
+
+
+def execCommand(args, following_args):
+    cwd = os.getcwd()
+
+    c = validate.currentDirectoryModule()
+    if not c:
+        return 1
+
+    if not c.isApplication():
+        logging.error('This module describes a library not an executable. Only executables can be started.')
+        return 1
+
+    target, errors = c.satisfyTarget(args.target, additional_config=args.config)
+    if errors:
+        for error in errors:
+            logging.error(error)
+        return 1
+
+    builddir = os.path.join(cwd, 'build', target.getName())
+
+    if args.program is None:
+        # if no program was specified, default to the name of the executable
+        # module (if this is an executable module)
+        args.program = c.getName()
+
+    errcode = None
+    error = target.start(builddir, args.program, following_args)
+    if error:
+        logging.error(error)
+        errcode = 1
+
+    return errcode
+
+

--- a/yotta/start.py
+++ b/yotta/start.py
@@ -44,7 +44,10 @@ def execCommand(args, following_args):
         # module (if this is an executable module)
         args.program = c.getName()
 
-    errcode = None
+    errcode = c.runScript('preStart', {"YOTTA_PROGRAM":args.program})
+    if errcode:
+        return errcode
+
     error = target.start(builddir, args.program, following_args)
     if error:
         logging.error(error)

--- a/yotta/test/cli/test_debug.py
+++ b/yotta/test/cli/test_debug.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# Copyright 2016 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library modules, , ,
+import unittest
+import os
+
+# internal modules:
+from yotta.test.cli import util
+from yotta.test.cli import cli
+
+def _nopDebugTargetDescription(name):
+    native_target = util.nativeTarget()
+    if ',' in native_target:
+        native_target = native_target[:native_target.find(',')]
+    return {
+    'target.json':'''{
+      "name": "%s",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "inherits": {
+        "%s": "*"
+      },
+      "scripts": {
+        "debug": ["./scripts/nop.py", "$program"]
+      }
+    }
+    ''' % (name, native_target),
+    './scripts/nop.py':'''
+import os
+print('would debug %s' % os.environ['YOTTA_PROGRAM'])
+    '''
+    }
+
+class TestCLIDebug(unittest.TestCase):
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_noop_debug(self):
+        test_dir = util.writeTestFiles(util.Test_Trivial_Exe, True)
+        util.writeTestFiles(_nopDebugTargetDescription('debug-test-target'), test_dir=os.path.join(test_dir, 'yotta_targets', 'debug-test-target'))
+        output = util.runCheckCommand(['--target', 'debug-test-target', 'build'], test_dir)
+        output = util.runCheckCommand(['--target', 'debug-test-target', 'debug'], test_dir)
+        self.assertIn('would debug source/test-trivial-exe', output)
+        util.rmRf(test_dir)
+
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_notfound_debug(self):
+        test_dir = util.writeTestFiles(util.Test_Trivial_Exe, True)
+        target_descr = _nopDebugTargetDescription('debug-test-target')
+        del target_descr['./scripts/nop.py']
+        util.writeTestFiles(target_descr, test_dir=os.path.join(test_dir, 'yotta_targets', 'debug-test-target'))
+
+        # in this case, without the script present we expect a failure
+        output = util.runCheckCommand(['--target', 'debug-test-target', 'build'], test_dir)
+        stdout, stderr, statuscode = cli.run(['--target', 'debug-test-target', 'debug'], cwd=test_dir)
+        self.assertNotEqual(statuscode, 0)
+        util.rmRf(test_dir)
+
+

--- a/yotta/test/cli/test_publish.py
+++ b/yotta/test/cli/test_publish.py
@@ -73,6 +73,20 @@ int foo(){
 }'''
 }
 
+Test_prePublish_Prevents_Publish = {
+  'module.json':'''{
+  "name": "test-publish-prevented",
+  "version": "0.0.0",
+  "description": "Test yotta publish",
+  "author": "James Crosby <james.crosby@arm.com>",
+  "license": "Apache-2.0",
+  "scripts": {
+    "prePublish": "false"
+  }
+}''',
+'readme.md':'''##This is a test module used in yotta's test suite.''',
+}
+
 
 class TestCLIPublish(unittest.TestCase):
     @classmethod
@@ -108,6 +122,15 @@ class TestCLIPublish(unittest.TestCase):
                 os.environ['YOTTA_USER_SETTINGS_DIR'] = saved_settings_dir
             else:
                 del os.environ['YOTTA_USER_SETTINGS_DIR']
+
+    def test_prePublishPreventsPublish(self):
+        path = util.writeTestFiles(Test_prePublish_Prevents_Publish, True)
+
+        stdout, stderr, statuscode = cli.run(['-t', 'x86-linux-native', '--noninteractive', 'publish'], cwd=path)
+        self.assertNotEqual(statuscode, 0)
+        self.assertIn('prePublish script error code 1 prevents publishing', stdout + stderr)
+
+        util.rmRf(path)
 
     def test_warnOfficialKeywords(self):
         path = util.writeTestFiles(Test_Publish, True)

--- a/yotta/test/cli/test_start.py
+++ b/yotta/test/cli/test_start.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# Copyright 2016 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library modules, , ,
+import unittest
+import os
+
+# internal modules:
+from yotta.test.cli import util
+from yotta.test.cli import cli
+
+def _nopStartTargetDescription(name):
+    native_target = util.nativeTarget()
+    if ',' in native_target:
+        native_target = native_target[:native_target.find(',')]
+    return {
+    'target.json':'''{
+      "name": "%s",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "inherits": {
+        "%s": "*"
+      },
+      "scripts": {
+        "start": ["./scripts/nop.py", "$program"]
+      }
+    }
+    ''' % (name, native_target),
+    './scripts/nop.py':'''
+import os
+print('would start %s' % os.environ['YOTTA_PROGRAM'])
+    '''
+    }
+
+class TestCLIStart(unittest.TestCase):
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_noop_start(self):
+        test_dir = util.writeTestFiles(util.Test_Trivial_Exe, True)
+        util.writeTestFiles(_nopStartTargetDescription('start-test-target'), test_dir=os.path.join(test_dir, 'yotta_targets', 'start-test-target'))
+        output = util.runCheckCommand(['--target', 'start-test-target', 'build'], test_dir)
+        output = util.runCheckCommand(['--target', 'start-test-target', 'start'], test_dir)
+        self.assertIn('would start source/test-trivial-exe', output)
+        util.rmRf(test_dir)
+
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_native_start(self):
+        test_dir = util.writeTestFiles(util.Test_Trivial_Exe, True)
+        output = util.runCheckCommand(['--target', util.nativeTarget(), 'build'], test_dir)
+        output = util.runCheckCommand(['--target', util.nativeTarget(), 'start'], test_dir)
+        self.assertIn('[trivial-exe-running]', output)
+        util.rmRf(test_dir)
+
+    @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
+    def test_notfound_start(self):
+        test_dir = util.writeTestFiles(util.Test_Trivial_Exe, True)
+        target_descr = _nopStartTargetDescription('start-test-target')
+        del target_descr['./scripts/nop.py']
+        util.writeTestFiles(target_descr, test_dir=os.path.join(test_dir, 'yotta_targets', 'start-test-target'))
+
+        # in this case, without the script present we expect a failure
+        output = util.runCheckCommand(['--target', 'start-test-target', 'build'], test_dir)
+        stdout, stderr, statuscode = cli.run(['--target', 'start-test-target', 'start'], cwd=test_dir)
+        self.assertNotEqual(statuscode, 0)
+        util.rmRf(test_dir)
+
+

--- a/yotta/test/cli/util.py
+++ b/yotta/test/cli/util.py
@@ -12,6 +12,7 @@ import copy
 # internal modules:
 from yotta.lib import fsutils
 from yotta.lib.detect import systemDefaultTarget
+from yotta.test.cli import cli
 
 # some simple example module definitions that can be re-used by multiple tests:
 Test_Trivial_Lib = {
@@ -64,7 +65,8 @@ Test_Trivial_Exe = {
 }''',
 
 'source/lib.c':'''
-int main(){ return 0; }
+#include <stdio.h>
+int main(){ printf("[trivial-exe-running]\\n"); return 0; }
 '''
 }
 
@@ -299,6 +301,15 @@ def canBuildNatively():
 def nativeTarget():
     assert(canBuildNatively())
     return systemDefaultTarget()
+
+def runCheckCommand(args, test_dir):
+    stdout, stderr, statuscode = cli.run(args, cwd=test_dir)
+    if statuscode != 0:
+        print('command failed with status %s' % statuscode)
+        print(stdout)
+        print(stderr)
+    assert(statuscode == 0)
+    return '%s %s' % (stdout, stderr)
 
 def setupGitUser():
     # override the git user for subprocesses:

--- a/yotta/test_subcommand.py
+++ b/yotta/test_subcommand.py
@@ -140,6 +140,10 @@ def execCommand(args, following_args):
     # tests, in case the specific test does not belong to this module
     tests = findCTests(builddir, recurse_yotta_modules=(all_tests or len(args.tests)))
 
+    errcode = c.runScript('preTest')
+    if errcode:
+        return errcode
+
     passed = 0
     failed = 0
     for dirname, test_definitions in tests:
@@ -148,7 +152,7 @@ def execCommand(args, following_args):
         if (not len(args.tests)) and (module is not c) and not all_tests:
             continue
         info_filter = True
-        filter_command = module.getTestFilterCommand()
+        filter_command = module.getScript('testReporter')
         for test_name, test_command in test_definitions:
             if len(args.tests) and not test_name in args.tests:
                 logging.debug('skipping not-listed test %s: %s', test_name, test_command)


### PR DESCRIPTION
 * Adds `yotta start` aka `yotta run` defined by targets (defaulted to native execution).
 * Adds  prePublish, postPublish, postInstall, preGenerate, preBuild and postBuild module-defined scripts (plan to add also preTest, preDebug and preStart scripts)
 * Fixes #518
 * Fixes #278 
 * Fixes the use case in #611 (though not the request for arbitrary scripts)
 * Also some other bugfixes and improvements for the existing `test` and `debug` script support.
 * Fixes #234 (.py scripts can be used as testReporters, and their path is interpreted relative to the root of the module)
