### PR TITLE
Fix 448

### DIFF
--- a/yotta/lib/target.py
+++ b/yotta/lib/target.py
@@ -163,7 +163,7 @@ def getDerivedTarget(
                                  type = 'target',
                    inherit_shrinkwrap = shrinkwrap
                 )
-        except access_common.Unavailable as e:
+        except access_common.AccessException as e:
             errors.append(e)
         if not t:
             if install_missing:


### PR DESCRIPTION
 * also improves support for `yotta target <targetname>@<version>` (allowing @ instead of , as the separator, and widening the number of things that are accepted as <version> to include all version specifications and source URL formats)