### PR TITLE
Link path

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -398,12 +398,13 @@ Synonyms: `yotta ln`
 ```
 yotta link (in a module directory)
 yotta link <modulename>
+yotta link /path/to/a/module
 ```
 
 #### Description
 Module linking allows you to use local versions of modules when building other modules – it's useful when fixing a bug in a dependency that is most easily reproduced when that dependency is used by another module.
 
-To link a module you need to perform two steps. First, in the directory of the dependency:
+To link a module there are two steps. First, in the directory of the dependency:
 
 ```
 yotta link
@@ -420,6 +421,8 @@ yotta link <depended-on-module-name>
 When you run `yotta build` it will then pick up the linked module.
 
 This works for direct and indirect dependencies: you can link to a module that your module does not use directly, but a dependency of your module does.
+
+The variant of the command which takes a path to an existing module (e.g. `yotta link ../path/to/a/module`) performs both steps in sequence, for convenience.
 
 **WARNING:** yotta uses directory junctions to provide links on windows. **Some
 command line tools are not aware of directory junctions and will recurse
@@ -445,6 +448,7 @@ environment variable.
 ```
 yotta link-target (in a target directory)
 yotta link-target <targetename>
+yotta link-target /path/to/a/target
 ```
 
 #### Description
@@ -465,6 +469,11 @@ yotta link-target <targetename>
 ```
 
 When you run `yotta build` (provided you've set `yotta target` to `<targetname>`), the linked target description will be used.
+
+The variant of the command which takes a path to an existing module (e.g. `yotta link ../path/to/a/module`) performs both steps in sequence, for convenience.
+
+See also [yotta link](#yotta-link).
+
 
 ## <a href="#yotta-list" name="yotta-list">#</a> yotta list
 Synonyms: `yotta ls`

--- a/yotta/lib/pack.py
+++ b/yotta/lib/pack.py
@@ -548,6 +548,7 @@ class Pack(object):
             env.update(additional_environment)
 
         errcode = 0
+        child = None
         try:
             logger.debug('running script: %s', command)
             child = subprocess.Popen(

--- a/yotta/lib/validate.py
+++ b/yotta/lib/validate.py
@@ -67,6 +67,18 @@ def directoryModule(path):
         return None
     return c
 
+def directoryTarget(path):
+    # Target, , represents an installed target, internal
+    from yotta.lib import target
+    # Pack, , base class for targets and components, internal
+    from yotta.lib import pack
+    try:
+        t = target.Target(path)
+    except pack.InvalidDescription as e:
+        logging.error(e)
+        return None
+    return t
+
 def currentDirectoryModule():
     c = directoryModule(os.getcwd())
     if not c:
@@ -76,15 +88,7 @@ def currentDirectoryModule():
     return c
 
 def currentDirectoryTarget():
-    # Target, , represents an installed target, internal
-    from yotta.lib import target
-    # Pack, , base class for targets and components, internal
-    from yotta.lib import pack
-    try:
-        t = target.Target(os.getcwd())
-    except pack.InvalidDescription as e:
-        logging.error(e)
-        return None
+    t = directoryTarget(os.getcwd())
     if not t:
         logging.error(str(t.error))
         logging.error('The current directory does not contain a valid target.')

--- a/yotta/lib/validate.py
+++ b/yotta/lib/validate.py
@@ -55,17 +55,20 @@ def looksLikeAnEmail(email):
     else:
         return False
 
-def currentDirectoryModule():
+def directoryModule(path):
     # Component, , represents an installed component, internal
     from yotta.lib import component
     # Pack, , base class for targets and components, internal
     from yotta.lib import pack
     try:
-        c = component.Component(os.getcwd())
+        c = component.Component(path)
     except pack.InvalidDescription as e:
         logging.error(e)
         return None
+    return c
 
+def currentDirectoryModule():
+    c = directoryModule(os.getcwd())
     if not c:
         logging.error(str(c.error))
         logging.error('The current directory does not contain a valid module.')

--- a/yotta/link.py
+++ b/yotta/link.py
@@ -56,7 +56,7 @@ def execCommand(args, following_args):
                     logging.error("%s is not a valid module: %s", args.module_or_path, dep.getError())
                     return 1
                 link_module_name = dep.getName()
-                dst = os.path.join(folders.globalInstallDirectory(), dep.getName())
+                dst = os.path.join(folders.globalInstallDirectory(), link_module_name)
                 errcode = tryLink(src, dst)
                 if errcode:
                     return errcode

--- a/yotta/link_target.py
+++ b/yotta/link_target.py
@@ -3,26 +3,25 @@
 # Licensed under the Apache License, Version 2.0
 # See LICENSE file for details.
 
-# standard library modules, , ,
-import logging
-import os
-
-# colorama, BSD 3-Clause license, color terminal output, pip install colorama
-import colorama
-
-# fsutils, , misc filesystem utils, internal
-from yotta.lib import fsutils
-# validate, , validate things, internal
-from yotta.lib import validate
-# folders, , get places to install things, internal
-from yotta.lib import folders
-
 def addOptions(parser):
-    parser.add_argument('link_target', default=None, nargs='?',
+    parser.add_argument('target_or_path', default=None, nargs='?',
         help='Link a globally installed (or globally linked) target into '+
              'the current target\'s dependencies. If ommited, globally '+
              'link the current target.'
     )
+
+def tryLink(src, dst):
+    # fsutils, , misc filesystem utils, internal
+    from yotta.lib import fsutils
+    try:
+        fsutils.symlink(src, dst)
+    except Exception as e:
+        if src == fsutils.realpath(src):
+            logging.error('failed to create link (create the first half of the link first)')
+        else:
+            logging.error('failed to create link: %s', e)
+        return 1
+    return 0
 
 def nameFromTargetSpec(target_name_and_version):
     if ',' in target_name_and_version:
@@ -31,19 +30,50 @@ def nameFromTargetSpec(target_name_and_version):
         return target_name_and_version
 
 def execCommand(args, following_args):
+    # standard library modules, , ,
+    import logging
+    import os
+
+    # colorama, BSD 3-Clause license, color terminal output, pip install colorama
+    import colorama
+
+    # fsutils, , misc filesystem utils, internal
+    from yotta.lib import fsutils
+    # validate, , validate things, internal
+    from yotta.lib import validate
+    # folders, , get places to install things, internal
+    from yotta.lib import folders
     c = None
     t = None
-    if args.link_target:
+    link_target_name = None
+    if args.target_or_path:
+        link_target_name = args.target_or_path
         c = validate.currentDirectoryModule()
         if not c:
             return 1
-        err = validate.targetNameValidationError(args.link_target)
+        err = validate.targetNameValidationError(args.target_or_path)
         if err:
-            logging.error(err)
-            return 1
+            # check if the target name is really a path to an existing target
+            if os.path.isdir(args.target_or_path):
+                # make sure the first half of the link exists,
+                src = os.path.abspath(args.target_or_path)
+                print src
+                # if it isn't a valid target, that's an error:
+                tgt = validate.directoryTarget(src)
+                if not tgt:
+                    logging.error("%s is not a valid target: %s", args.target_or_path, tgt.getError())
+                    return 1
+                link_target_name = tgt.getName()
+                dst = os.path.join(folders.globalInstallDirectory(), link_target_name)
+                errcode = tryLink(src, dst)
+                if errcode:
+                    return errcode
+            else:
+                logging.error(err)
+                return 1
         fsutils.mkDirP(os.path.join(os.getcwd(), 'yotta_targets'))
-        src = os.path.join(folders.globalTargetInstallDirectory(), args.link_target)
-        dst = os.path.join(os.getcwd(), 'yotta_targets', args.link_target)
+        src = os.path.join(folders.globalTargetInstallDirectory(), link_target_name)
+        dst = os.path.join(os.getcwd(), 'yotta_targets', link_target_name)
         # if the target is already installed, rm it
         fsutils.rmRf(dst)
     else:
@@ -55,7 +85,7 @@ def execCommand(args, following_args):
         dst = os.path.join(folders.globalTargetInstallDirectory(), t.getName())
 
     broken_link = False
-    if args.link_target:
+    if link_target_name:
         realsrc = fsutils.realpath(src)
         if src == realsrc:
             broken_link = True
@@ -67,23 +97,23 @@ def execCommand(args, following_args):
         # check that the linked target is actually set as the target (or is
         # inherited from by something set as the target), if it isn't, warn the
         # user:
-        if c and args.link_target != nameFromTargetSpec(args.target):
+        if c and link_target_name != nameFromTargetSpec(args.target):
             target = c.getTarget(args.target, args.config)
             if target:
-                if not target.inheritsFrom(args.link_target):
+                if not target.inheritsFrom(link_target_name):
                     logging.warning(
                         'target "%s" is not used by the current target (%s), so '
                         'this link will have no effect. Perhaps you meant to '
                         'use "yotta target <targetname>" to set the build '
                         'target first.',
-                        args.link_target,
+                        link_target_name,
                         nameFromTargetSpec(args.target)
                     )
             else:
                 logging.warning(
                     'Could not check if linked target "%s" is used by the '+
                     'current target "%s": run "yotta target" to check.',
-                    args.link_target,
+                    link_target_name,
                     nameFromTargetSpec(args.target)
                 )
 

--- a/yotta/link_target.py
+++ b/yotta/link_target.py
@@ -57,7 +57,6 @@ def execCommand(args, following_args):
             if os.path.isdir(args.target_or_path):
                 # make sure the first half of the link exists,
                 src = os.path.abspath(args.target_or_path)
-                print src
                 # if it isn't a valid target, that's an error:
                 tgt = validate.directoryTarget(src)
                 if not tgt:

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -135,10 +135,12 @@ def main():
         'Symlink a module'
     )
     addParser('link-target', 'link_target',
-        'Symlink a target to be used in another module. Use "yotta link-target" '+
-        '(with no arguments) to link the current target globally. Or use '+
-        '"yotta link-target target-name" To use a target that was previously linked '+
-        'globally in the current module.',
+        'Symlink a target to be used into another module.\n\n'+
+        'Use: "yotta link" in a target to link it globally, then use "yotta '+
+        'link-target <targetname>" to link it into the module where you want to use '+
+        'it.\n\n'+
+        '"yotta link ../path/to/target" is also supported, which will create '+
+        'the global link and a link into the current module in a single step.',
         'Symlink a target'
     )
     addParser('update', 'update', 'Update dependencies for the current module, or a specific module.')

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -126,10 +126,12 @@ def main():
     )
     addParser('version', 'version', 'Bump the module version, or (with no arguments) display the current version.')
     addParser('link', 'link',
-        'Symlink a module to be used in another module. Use "yotta link" '+
-        '(with no arguments) to link the current module globally. Or use '+
-        '"yotta link module-name" To use a module that was previously linked '+
-        'globally in the current module.',
+        'Symlink a module to be used into another module.\n\n'+
+        'Use: "yotta link" in a module to link it globally, then use "yotta '+
+        'link <modulename>" to link it into the module where you want to use '+
+        'it.\n\n'+
+        '"yotta link ../path/to/module" is also supported, which will create '+
+        'the global link and a link into the current module in a single step.',
         'Symlink a module'
     )
     addParser('link-target', 'link_target',


### PR DESCRIPTION
Support for `yotta link ../path/to/a/module` and `yotta link-target ../path/to/a/target`, so you don't have to two two steps.

Note that these still create two links (one into the global dir, and one from the global dir locally).
