### PR TITLE
Add $build_dir and $target_dir variables for target scripts

### DIFF
--- a/yotta/test/cli/test_debug.py
+++ b/yotta/test/cli/test_debug.py
@@ -5,6 +5,7 @@
 # See LICENSE file for details.
 
 # standard library modules, , ,
+import json
 import unittest
 import os
 
@@ -12,6 +13,7 @@ import os
 from yotta.test.cli import util
 from yotta.test.cli import cli
 
+JSON_MARKER = '###---###'
 def _nopDebugTargetDescription(name):
     native_target = util.nativeTarget()
     if ',' in native_target:
@@ -25,24 +27,43 @@ def _nopDebugTargetDescription(name):
         "%s": "*"
       },
       "scripts": {
-        "debug": ["./scripts/nop.py", "$program"]
+        "debug": ["./scripts/nop.py", "$program", "$build_dir", "$target_dir"]
       }
     }
     ''' % (name, native_target),
     './scripts/nop.py':'''
 import os
-print('would debug %s' % os.environ['YOTTA_PROGRAM'])
-    '''
+import sys
+import json
+
+env_keys = ["YOTTA_PROGRAM", "YOTTA_BUILD_DIR", "YOTTA_TARGET_DIR"]
+print(json.dumps({"argv": sys.argv[1:], "env": {k: v for k, v in os.environ.items() if k in env_keys}}))
+print('%s')
+    ''' % JSON_MARKER
     }
 
 class TestCLIDebug(unittest.TestCase):
     @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")
     def test_noop_debug(self):
         test_dir = util.writeTestFiles(util.Test_Trivial_Exe, True)
-        util.writeTestFiles(_nopDebugTargetDescription('debug-test-target'), test_dir=os.path.join(test_dir, 'yotta_targets', 'debug-test-target'))
+        target_dir = os.path.realpath(os.path.join(test_dir, 'yotta_targets', 'debug-test-target'))
+        build_dir = os.path.realpath(os.path.join(test_dir, 'build', 'debug-test-target'))
+
+        util.writeTestFiles(_nopDebugTargetDescription('debug-test-target'), test_dir=target_dir)
         output = util.runCheckCommand(['--target', 'debug-test-target', 'build'], test_dir)
         output = util.runCheckCommand(['--target', 'debug-test-target', 'debug'], test_dir)
-        self.assertIn('would debug source/test-trivial-exe', output)
+        json_output = output[:output.index(JSON_MARKER)]
+        result = json.loads(json_output)
+
+        self.assertTrue(result is not None)
+        self.assertEqual(len(result['argv']), 3)
+        self.assertEqual(result['argv'][0], 'source/test-trivial-exe')
+        self.assertEqual(result['env']['YOTTA_PROGRAM'], 'source/test-trivial-exe')
+        self.assertEqual(result['argv'][1], build_dir)
+        self.assertEqual(result['env']['YOTTA_BUILD_DIR'], build_dir)
+        self.assertEqual(result['argv'][2], target_dir)
+        self.assertEqual(result['env']['YOTTA_TARGET_DIR'], target_dir)
+
         util.rmRf(test_dir)
 
     @unittest.skipIf(not util.canBuildNatively(), "can't build natively on windows yet")


### PR DESCRIPTION
This feature makes two new variables available to target scripts:
* `$build_dir` points to the root of the module's build directory, and is mirrored by the environment variable `YOTTA_BUILD_DIR`
* `$target_dir` points to the directory of the installed target, and is mirrored by the environment variable `YOTTA_TARGET_DIR`

Since there were a lot of places that manually constructed the script environment and template variables, I wrote a new function called `buildProgEnvAndVars` to make logic like this easier to update in the future.

I also updated the unit test `test/cli/test_debug.py` to verify these new values.

Would love some feedback! I am using this feature in a target that I created which includes some OpenOCD configuration scripts, and I needed a reliable way to get the target's installation directory so I could pass those scripts on to OpenOCD