### PR TITLE
Add missing logging module imports

### DIFF
--- a/yotta/link.py
+++ b/yotta/link.py
@@ -11,6 +11,9 @@ def addOptions(parser):
     )
 
 def tryLink(src, dst):
+    # standard library modules, , ,
+    import logging
+
     # fsutils, , misc filesystem utils, internal
     from yotta.lib import fsutils
     try:

--- a/yotta/link_target.py
+++ b/yotta/link_target.py
@@ -11,6 +11,9 @@ def addOptions(parser):
     )
 
 def tryLink(src, dst):
+    # standard library modules, , ,
+    import logging
+    
     # fsutils, , misc filesystem utils, internal
     from yotta.lib import fsutils
     try:


### PR DESCRIPTION
The `logging` module was not imported in `tryLink` method of `link` and `link-target` commands, resulting in a python NameError exception rather than the intended error message getting printed in the case the linking failed.
