### PR TITLE
Implement tipVersion for git repos

### DIFF
--- a/yotta/lib/git_access.py
+++ b/yotta/lib/git_access.py
@@ -73,7 +73,7 @@ class GitWorkingCopy(object):
 
 
     def tipVersion(self):
-        raise NotImplementedError
+        return GitCloneVersion('', '', self)
 
 
 class GitComponent(access_common.RemoteComponent):


### PR DESCRIPTION
Without this change, using non-github git repos as dependencies hits this function and crashes if they don't have any tags.

For example if you create a local yotta repo without tags, and then specify it as a dependency like this then it crashes:

```
dependencies: { "../mylib/.git" }
```

Note that I don't fully understand the code so it would benefit from review by someone more familiar. I wrote this patch by comparison with `github_access.py`. I have tested it and it works though.
