### PR TITLE
Git and GitHub support rework

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -534,7 +534,7 @@ example:
 
 
 ## <a href="#yotta-uninstall" name="yotta-uninstall">#</a> yotta uninstall
-Synonyms: `yotta unlink`, `yotta rm`
+Synonyms: `yotta unlink`, `yotta rm`, `yotta un`
 #### Synopsis
 
 ```

--- a/docs/reference/module.md
+++ b/docs/reference/module.md
@@ -198,6 +198,10 @@ To specify a dependency on a github module, use one of the following forms:
 
     Uses the latest committed version on the specified branch.
 
+ * `"usefulmodule": "username/repositoryname#commit-id"`
+
+    Uses the specified commit ID.
+
 #### Depending on git Modules
 To specify a module available from a non-Github git server as a dependency, use
 a git URL:
@@ -206,8 +210,9 @@ a git URL:
  * `"usefulmodule": "git+ssh://somwhere.com/anything/anywhere#<version specification>"`
  * `"usefulmodule": "git+ssh://somwhere.com/anything/anywhere#<branch name>"`
  * `"usefulmodule": "git+ssh://somwhere.com/anything/anywhere#<tag name>"`
+ * `"usefulmodule": "git+ssh://somwhere.com/anything/anywhere#<commit id>"`
  * `"usefulmodule": "<anything>://somwhere.git"`
- * `"usefulmodule": "<anything>://somwhere.git#<version spec, tag, or branch name>"`
+ * `"usefulmodule": "<anything>://somwhere.git#<version spec, tag, branch name or commit id>"`
 
 #### Depending on hg Modules
 To specify a module available from a mercurial server as a dependency, use

--- a/docs/tutorial/privaterepos.md
+++ b/docs/tutorial/privaterepos.md
@@ -28,6 +28,7 @@ You can specify a particular branch, tag or commit to use by providing it in the
 
 ```
 username/reponame
+username/reponame#<versionspec>
 username/reponame#<branchname>
 username/reponame#<tagname>
 username/reponame#<commit>

--- a/docs/tutorial/privaterepos.md
+++ b/docs/tutorial/privaterepos.md
@@ -24,13 +24,13 @@ Sometimes it may not be appropriate publish a module to the public package regis
 
 The shorthand GitHub URL is formed of two parts: `<username>/<reponame>` where `<username>` is the GitHub user or organisation name of the repository owner and `<reponame>` is the name of the repositiry. e.g. the `yotta` repositry can be found at `ARMmbed/yotta`.
 
-You can specify a particular branch or tag to use by providing it in the URL. The supported GitHub URL formats are:
+You can specify a particular branch, tag or commit to use by providing it in the URL. The supported GitHub URL formats are:
 
 ```
 username/reponame
-username/reponame#<versionspec>
 username/reponame#<branchname>
 username/reponame#<tagname>
+username/reponame#<commit>
 ```
 
 
@@ -47,13 +47,13 @@ For example, to include a privately hosted git repository from example.com:
 ...
 ```
 
-Git URLs support branch, version and tags specifications:
+Git URLs support branch, version, tag and commit specifications:
 
 ```
 git+ssh://example.com/path/to/repo
-git+ssh://example.com/path/to/repo#<versionspec, branch or tag>
+git+ssh://example.com/path/to/repo#<versionspec, branch, tag or commit>
 anything://example.com/path/to/repo.git
-anything://example.com/path/to/repo.git#<versionspec, branch or tag>
+anything://example.com/path/to/repo.git#<versionspec, branch, tag or commit>
 ```
 
 Currently, mercurial URLs only support a version specification:

--- a/docs/tutorial/privaterepos.md
+++ b/docs/tutorial/privaterepos.md
@@ -31,11 +31,25 @@ username/reponame
 username/reponame#<branchname>
 username/reponame#<tagname>
 username/reponame#<commit>
+https://github.com/username/reponame
+https://github.com/username/reponame#<branchname>
+https://github.com/username/reponame#<tagname>
+https://github.com/username/reponame#<commit>
 ```
 
+If the GitHub repository is public, the dependency will simply be downloaded. If the GitHub repository is private and this is the first time you are downloading from a private GitHub repository, you will be prompted to log in to GitHub using a URL.
+
+If you have a private GitHub repository and you would prefer to download it using SSH keys, you can use the following dependency form:
+
+```
+git@github.com:username/reponame.git
+git@github.com:username/reponame.git#<branchname>
+git@github.com:username/reponame.git#<tagname>
+git@github.com:username/reponame.git#<commit>
+```
 
 ###Other ways to depend on private repositories 
-Using shorthand GitHub URLs is the easiest and reccomneded method of working with private repositories, however as not all projects are hosted on GitHub, `yotta` supports using git and hg URLs directly as well.
+Using shorthand GitHub URLs is the easiest and recommended method of working with private repositories, however as not all projects are hosted on GitHub, `yotta` supports using git and hg URLs directly as well.
 
 For example, to include a privately hosted git repository from example.com:
 

--- a/yotta/install.py
+++ b/yotta/install.py
@@ -167,7 +167,12 @@ def installComponentAsDependency(args, current_component):
     # (if it is not already present), and write that back to disk. Without
     # writing to disk the dependency wouldn't be usable.
     if installed and not current_component.hasDependency(component_name):
-        saved_spec = current_component.saveDependency(installed)
+        vs = sourceparse.parseSourceURL(component_spec)
+        if vs.source_type == 'registry':
+            saved_spec = current_component.saveDependency(installed)
+        else:
+            saved_spec = current_component.saveDependency(installed, component_spec)
+
         current_component.writeDescription()
         logging.info('dependency %s: %s written to module.json', component_name, saved_spec)
     else:

--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -195,8 +195,14 @@ def latestSuitableVersion(name, version_required, registry='modules', quiet=Fals
             )
             if v:
                 return v
+
+            # we have passed a specific commit ID:
+            v = local_clone.commitVersion(remote_component.tagOrBranchSpec())
+            if v:
+                return v
+
             raise access_common.Unavailable(
-                '%s repository "%s" does not have any tags or branches matching "%s"' % (
+                '%s repository "%s" does not have any tags, branches or commits matching "%s"' % (
                     clone_type, version_required, spec
                 )
             )

--- a/yotta/lib/access.py
+++ b/yotta/lib/access.py
@@ -147,8 +147,14 @@ def latestSuitableVersion(name, version_required, registry='modules', quiet=Fals
             )
             if v:
                 return v
+
+            # we have passed a specific commit ID:
+            v = remote_component.commitVersion()
+            if v:
+                return v
+
             raise access_common.Unavailable(
-                'Github repository "%s" does not have any tags or branches matching "%s"' % (
+                'Github repository "%s" does not have any tags, branches or commits matching "%s"' % (
                     version_required, remote_component.tagOrBranchSpec()
                 )
             )

--- a/yotta/lib/git_access.py
+++ b/yotta/lib/git_access.py
@@ -75,6 +75,16 @@ class GitWorkingCopy(object):
     def tipVersion(self):
         raise NotImplementedError
 
+    def commitVersion(self, spec):
+        ''' return a GithubComponentVersion object for a specific commit if valid
+        '''
+        import re
+
+        commit_match = re.match('^[a-f0-9]{7,40}$', spec, re.I)
+        if commit_match:
+            return GitCloneVersion('', spec, self)
+
+        return None
 
 class GitComponent(access_common.RemoteComponent):
     def __init__(self, url, tag_or_branch=None, semantic_spec=None):

--- a/yotta/lib/github_access.py
+++ b/yotta/lib/github_access.py
@@ -141,6 +141,12 @@ def _getTipArchiveURL(repo):
     repo = g.get_repo(repo)
     return repo.get_archive_link('tarball')
 
+@_handleAuth
+def _getCommitArchiveURL(repo, commit):
+    ''' return a string containing a tarball url '''
+    g = Github(settings.getProperty('github', 'authtoken'))
+    repo = g.get_repo(repo)
+    return repo.get_archive_link('tarball', commit)
 
 @_handleAuth
 def _getTarball(url, into_directory, cache_key, origin_info=None):
@@ -282,6 +288,19 @@ class GithubComponent(access_common.RemoteComponent):
         return GithubComponentVersion(
             '', '', _getTipArchiveURL(self.repo), self.name, cache_key=None
         )
+
+    def commitVersion(self):
+        ''' return a GithubComponentVersion object for a specific commit if valid
+        '''
+        import re
+
+        commit_match = re.match('^[a-f0-9]{7,40}$', self.tagOrBranchSpec(), re.I)
+        if commit_match:
+            return GithubComponentVersion(
+                '', '', _getCommitArchiveURL(self.repo, self.tagOrBranchSpec()), self.name, cache_key=None
+            )
+
+        return None
 
     @classmethod
     def remoteType(cls):

--- a/yotta/lib/sourceparse.py
+++ b/yotta/lib/sourceparse.py
@@ -57,9 +57,9 @@ def _getNonRegistryRef(source_url):
     # something/something#spec = github
     # something/something@spec = github
     # something/something spec = github
-    github_match = re.match('^([.a-z0-9_-]+/([.a-z0-9_-]+))( *[ @#]([.a-z0-9_-]+))?$', source_url, re.I)
+    github_match = re.match('^([.a-z0-9_-]+/([.a-z0-9_-]+)) *[@#]?([.a-z0-9_\-\*\^\~\>\<\=]*)$', source_url, re.I)
     if github_match:
-        return github_match.group(2), VersionSource('github', github_match.group(1), github_match.group(4))
+        return github_match.group(2), VersionSource('github', github_match.group(1), github_match.group(3))
 
     parsed = urlsplit(source_url)
 

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -201,6 +201,7 @@ def main():
     short_commands = {
                 'up':subparser.choices['update'],
                 'in':subparser.choices['install'],
+                'un':subparser.choices['uninstall'],
                 'ln':subparser.choices['link'],
                  'v':subparser.choices['version'],
                 'ls':subparser.choices['list'],


### PR DESCRIPTION
This pull request fixes the following issues:

- Added support for Git and GitHub hash commits in package specifications
- Fixed the `install` command to correctly support all non-registry forms
- Fixed the saving of non-registry package specifications to `module.json`
- Additional tests for the above
- Updated docs for the above

Fixes #801, #691 and #566 

@bogdanm @marcuschangarm @yogpan01 @0xc0170 @bremoran @LiyouZhou @korjaa 