### PR TITLE
Bump cryptography version to >= 2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'colorama>=0.3,<0.4',
         'hgapi>=1.7,<2',
         'Jinja2>=2.7.0,<3',
-        'cryptography>=2.1.4,<=2.3',
+        'cryptography>=2.8,<3',
         'PyJWT>=1.0,<2.0',
         'pathlib>=1.0.1,<1.1',
         'jsonschema>=2.4.0,<3.0',


### PR DESCRIPTION
`requests[security]` depends on `pyOpenSSL` which requires `cryptography >= 2.8`, we were pinning `cryptography` to `<=2.3`.

This patch bumps the minimum `cryptography` version to 2.8.

This is a fix for https://github.com/ARMmbed/yotta/issues/860